### PR TITLE
Proactively refresh the intake connection periodically.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,6 +55,7 @@ var (
 	eksRegion            string
 	eksClusterName       string
 	eksAutodiscover      bool
+	maxStreamAge         time.Duration
 )
 
 func init() {
@@ -97,6 +98,8 @@ func init() {
 		"The name of the EKS cluster")
 	flag.BoolVar(&eksAutodiscover, "kubernetes-provider-eks-autodiscover", true,
 		"Autodiscover EKS cluster name")
+	flag.DurationVar(&maxStreamAge, "max-stream-age", 10*time.Minute,
+		"Maximum age of the intake stream before it is reset")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -197,6 +200,7 @@ func main() {
 		intake.WithLogger(mgr.GetLogger().WithName("intake-worker")),
 		intake.WithGRPCConn(intakeConn),
 		intake.WithAPIKey(intakeAPIKey),
+		intake.WithMaxStreamAge(maxStreamAge),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create intake worker")

--- a/internal/intake/worker.go
+++ b/internal/intake/worker.go
@@ -273,6 +273,14 @@ func (w *worker) sendDelta(ctx context.Context) {
 	defer w.queue.Done(batch)
 
 	if w.stream == nil || time.Since(w.streamCreatedAt) > w.maxStreamAge {
+
+		if w.stream != nil {
+			err := w.stream.CloseSend()
+			if err != nil {
+				w.logger.Error(err, "failed to close old intake stream")
+			}
+		}
+
 		for {
 			_, err := backoff.Retry(ctx, func() (bool, error) {
 				streamCtx := metadata.NewOutgoingContext(


### PR DESCRIPTION
- adds flag for max duration to keep the connection open
- adds logic to refresh the connection if it has been open for too long