### PR TITLE
feat: Add TCP collector for network performance monitoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.6.0
 	github.com/go-logr/logr v1.4.2
 	github.com/gogo/protobuf v1.3.2
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.69.4
 	google.golang.org/protobuf v1.36.5
@@ -73,6 +74,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/pkg/performance/collector.go
+++ b/pkg/performance/collector.go
@@ -81,6 +81,10 @@ func (b *BaseCollector) Capabilities() CollectorCapabilities {
 	return b.capabilities
 }
 
+func (b *BaseCollector) Logger() logr.Logger {
+	return b.logger
+}
+
 type BaseContinuousCollector struct {
 	BaseCollector
 	status    CollectorStatus

--- a/pkg/performance/collectors/tcp.go
+++ b/pkg/performance/collectors/tcp.go
@@ -1,0 +1,367 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+)
+
+// Compile-time interface check
+var _ performance.Collector = (*TCPCollector)(nil)
+
+// TCPCollector collects TCP connection statistics from /proc/net/snmp, /proc/net/netstat, /proc/net/tcp*
+//
+// This collector reads TCP statistics from multiple proc files:
+// - /proc/net/snmp: Basic TCP statistics (RFC 1213 MIB-II)
+// - /proc/net/netstat: Extended TCP statistics (Linux-specific)
+// - /proc/net/tcp: IPv4 TCP connection states
+// - /proc/net/tcp6: IPv6 TCP connection states
+//
+// The statistics help monitor TCP performance, connection health, and
+// potential issues like SYN floods, connection drops, and retransmissions.
+//
+// References:
+// - https://www.kernel.org/doc/html/latest/networking/proc_net_tcp.html
+// - https://www.kernel.org/doc/html/latest/networking/snmp_counter.html
+type TCPCollector struct {
+	performance.BaseCollector
+	snmpPath    string
+	netstatPath string
+	tcpPath     string
+	tcp6Path    string
+}
+
+// TCP connection state mappings from kernel
+// These hexadecimal values correspond to the TCP state enum in the kernel
+// Reference: include/net/tcp_states.h
+var tcpStates = map[string]string{
+	"01": "ESTABLISHED", // Connection established
+	"02": "SYN_SENT",    // Sent SYN, waiting for SYN-ACK
+	"03": "SYN_RECV",    // Received SYN, sent SYN-ACK
+	"04": "FIN_WAIT1",   // Sent FIN, waiting for ACK or FIN
+	"05": "FIN_WAIT2",   // Received ACK of FIN, waiting for FIN
+	"06": "TIME_WAIT",   // Waiting for 2*MSL timeout
+	"07": "CLOSE",       // Connection closed
+	"08": "CLOSE_WAIT",  // Received FIN, waiting for app to close
+	"09": "LAST_ACK",    // Sent FIN after receiving FIN, waiting for ACK
+	"0A": "LISTEN",      // Listening for incoming connections
+	"0B": "CLOSING",     // Simultaneous close, waiting for ACK
+}
+
+func NewTCPCollector(logger logr.Logger, config performance.CollectionConfig) *TCPCollector {
+	capabilities := performance.CollectorCapabilities{
+		SupportsOneShot:    true,
+		SupportsContinuous: false,
+		RequiresRoot:       false,
+		RequiresEBPF:       false,
+		MinKernelVersion:   "2.6.0", // /proc/net/snmp has been around for a long time
+	}
+
+	return &TCPCollector{
+		BaseCollector: performance.NewBaseCollector(
+			performance.MetricTypeTCP,
+			"TCP Statistics Collector",
+			logger,
+			config,
+			capabilities,
+		),
+		snmpPath:    filepath.Join(config.HostProcPath, "net", "snmp"),
+		netstatPath: filepath.Join(config.HostProcPath, "net", "netstat"),
+		tcpPath:     filepath.Join(config.HostProcPath, "net", "tcp"),
+		tcp6Path:    filepath.Join(config.HostProcPath, "net", "tcp6"),
+	}
+}
+
+func (c *TCPCollector) Collect(ctx context.Context) (any, error) {
+	return c.collectTCPStats()
+}
+
+// collectTCPStats gathers TCP statistics from multiple proc files
+func (c *TCPCollector) collectTCPStats() (*performance.TCPStats, error) {
+	stats := &performance.TCPStats{
+		ConnectionsByState: make(map[string]uint64),
+	}
+
+	// Parse /proc/net/snmp for basic TCP statistics
+	if err := c.parseSNMP(stats); err != nil {
+		return nil, fmt.Errorf("failed to parse SNMP stats: %w", err)
+	}
+
+	// Parse /proc/net/netstat for extended TCP statistics
+	if err := c.parseNetstat(stats); err != nil {
+		// This is optional, so just log the error
+		c.Logger().V(1).Info("failed to parse netstat (continuing)", "error", err)
+	}
+
+	// Count TCP connections by state
+	if err := c.countConnectionStates(stats); err != nil {
+		// This is optional, so just log the error
+		c.Logger().V(1).Info("failed to count connection states (continuing)", "error", err)
+	}
+
+	return stats, nil
+}
+
+// parseSNMP parses /proc/net/snmp for TCP statistics
+//
+// /proc/net/snmp format:
+//
+//	Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+//	Tcp: 1 200 120000 -1 12345 67890 123 456 789 1234567 7654321 12345 0 123 0
+//
+// The file contains pairs of lines for each protocol:
+// - First line: Field names
+// - Second line: Corresponding values
+//
+// These are standard TCP MIB-II counters defined in RFC 1213.
+func (c *TCPCollector) parseSNMP(stats *performance.TCPStats) error {
+	file, err := os.Open(c.snmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", c.snmpPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var tcpHeader []string
+	var tcpValues []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 2 {
+			continue
+		}
+
+		// Look for TCP statistics
+		if fields[0] == "Tcp:" {
+			if tcpHeader == nil {
+				// This is the header line
+				tcpHeader = fields[1:]
+			} else {
+				// This is the values line
+				tcpValues = fields[1:]
+				break
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading %s: %w", c.snmpPath, err)
+	}
+
+	if len(tcpHeader) == 0 || len(tcpValues) == 0 {
+		return fmt.Errorf("TCP statistics not found in %s", c.snmpPath)
+	}
+
+	if len(tcpHeader) != len(tcpValues) {
+		return fmt.Errorf("TCP header/value length mismatch: %d != %d", len(tcpHeader), len(tcpValues))
+	}
+
+	// Map the values to our struct fields
+	for i, header := range tcpHeader {
+		value, err := strconv.ParseUint(tcpValues[i], 10, 64)
+		if err != nil {
+			continue // Skip fields we can't parse
+		}
+
+		switch header {
+		case "ActiveOpens":
+			stats.ActiveOpens = value
+		case "PassiveOpens":
+			stats.PassiveOpens = value
+		case "AttemptFails":
+			stats.AttemptFails = value
+		case "EstabResets":
+			stats.EstabResets = value
+		case "CurrEstab":
+			stats.CurrEstab = value
+		case "InSegs":
+			stats.InSegs = value
+		case "OutSegs":
+			stats.OutSegs = value
+		case "RetransSegs":
+			stats.RetransSegs = value
+		case "InErrs":
+			stats.InErrs = value
+		case "OutRsts":
+			stats.OutRsts = value
+		case "InCsumErrors":
+			stats.InCsumErrors = value
+		default:
+			// Log unknown fields at debug level
+			c.Logger().V(2).Info("Unknown TCP field in SNMP", "field", header, "value", value)
+		}
+	}
+
+	return nil
+}
+
+// parseNetstat parses /proc/net/netstat for extended TCP statistics
+//
+// /proc/net/netstat format is similar to /proc/net/snmp:
+//
+//	TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed ... TCPTimeouts ...
+//	TcpExt: 123 456 789 ... 12345 ...
+//
+// These are Linux-specific TCP extensions not covered by standard MIB-II.
+// They provide detailed insights into TCP behavior and performance issues.
+func (c *TCPCollector) parseNetstat(stats *performance.TCPStats) error {
+	file, err := os.Open(c.netstatPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", c.netstatPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var tcpExtHeader []string
+	var tcpExtValues []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 2 {
+			continue
+		}
+
+		// Look for TcpExt statistics
+		if fields[0] == "TcpExt:" {
+			if tcpExtHeader == nil {
+				// This is the header line
+				tcpExtHeader = fields[1:]
+			} else {
+				// This is the values line
+				tcpExtValues = fields[1:]
+				break
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading %s: %w", c.netstatPath, err)
+	}
+
+	if len(tcpExtHeader) == 0 || len(tcpExtValues) == 0 {
+		// TcpExt might not be present on all systems
+		return nil
+	}
+
+	if len(tcpExtHeader) != len(tcpExtValues) {
+		return fmt.Errorf("TcpExt header/value length mismatch: %d != %d", len(tcpExtHeader), len(tcpExtValues))
+	}
+
+	// Map the values to our struct fields
+	for i, header := range tcpExtHeader {
+		value, err := strconv.ParseUint(tcpExtValues[i], 10, 64)
+		if err != nil {
+			continue // Skip fields we can't parse
+		}
+
+		switch header {
+		case "SyncookiesSent":
+			stats.SyncookiesSent = value
+		case "SyncookiesRecv":
+			stats.SyncookiesRecv = value
+		case "SyncookiesFailed":
+			stats.SyncookiesFailed = value
+		case "ListenOverflows":
+			stats.ListenOverflows = value
+		case "ListenDrops":
+			stats.ListenDrops = value
+		case "TCPLostRetransmit":
+			stats.TCPLostRetransmit = value
+		case "TCPFastRetrans":
+			stats.TCPFastRetrans = value
+		case "TCPSlowStartRetrans":
+			stats.TCPSlowStartRetrans = value
+		case "TCPTimeouts":
+			stats.TCPTimeouts = value
+		}
+	}
+
+	return nil
+}
+
+// countConnectionStates counts TCP connections by state from /proc/net/tcp and /proc/net/tcp6
+func (c *TCPCollector) countConnectionStates(stats *performance.TCPStats) error {
+	// Initialize all known states to 0
+	for _, state := range tcpStates {
+		stats.ConnectionsByState[state] = 0
+	}
+
+	// Count IPv4 connections
+	if err := c.countConnectionsFromFile(c.tcpPath, stats); err != nil {
+		c.Logger().V(1).Info("failed to count IPv4 connections", "error", err)
+	}
+
+	// Count IPv6 connections
+	if err := c.countConnectionsFromFile(c.tcp6Path, stats); err != nil {
+		c.Logger().V(1).Info("failed to count IPv6 connections", "error", err)
+	}
+
+	return nil
+}
+
+// countConnectionsFromFile counts connections by state from a single tcp file
+//
+// /proc/net/tcp format (each line represents one connection):
+//
+//	sl  local_address rem_address   st tx_queue:rx_queue tr:tm->when retrnsmt   uid  timeout inode
+//	0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000   1000  0 12345 1 0000000000000000 100 0 0 10 0
+//
+// Fields we care about:
+// - sl: Entry number
+// - local_address: Local IP:Port in hex
+// - rem_address: Remote IP:Port in hex
+// - st: Connection state in hex (see tcpStates map)
+//
+// The same format applies to /proc/net/tcp6 for IPv6 connections.
+func (c *TCPCollector) countConnectionsFromFile(path string, stats *performance.TCPStats) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		if lineNum == 1 {
+			// Skip header line
+			continue
+		}
+
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		// Format: sl local_address rem_address st tx_queue:rx_queue ...
+		// We need at least 4 fields to get the state
+		if len(fields) < 4 {
+			continue
+		}
+
+		// State is in the 4th field (index 3)
+		stateHex := fields[3]
+		if stateName, ok := tcpStates[stateHex]; ok {
+			stats.ConnectionsByState[stateName]++
+		}
+	}
+
+	return scanner.Err()
+}

--- a/pkg/performance/collectors/tcp_test.go
+++ b/pkg/performance/collectors/tcp_test.go
@@ -1,0 +1,413 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/antimetal/agent/pkg/performance/collectors"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test data constants
+const (
+	validSNMPHeader = `Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
+Ip: 1 64 1000 0 0 0 0 0 1000 1000 0 0 0 0 0 0 0 0 0
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 100 200 10 5 8 50000 40000 500 2 15 3`
+
+	validNetstatHeader = `TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSPassive PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPFACKReorder TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPForwardRetrans TCPSlowStartRetrans TCPTimeouts
+TcpExt: 10 5 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 20 15 0 0 0 0 0 0 0 0 0 0 0 0 0 25 0 0 0 30 0 35 40`
+
+	validTCPHeader = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode`
+
+	validTCP6Header = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode`
+)
+
+func createTestCollector(t *testing.T, procPath string) *collectors.TCPCollector {
+	config := performance.CollectionConfig{
+		HostProcPath: procPath,
+		EnabledCollectors: map[performance.MetricType]bool{
+			performance.MetricTypeTCP: true,
+		},
+	}
+	return collectors.NewTCPCollector(logr.Discard(), config)
+}
+
+func setupTestFiles(t *testing.T, files map[string]string) string {
+	tempDir := t.TempDir()
+	netDir := filepath.Join(tempDir, "net")
+	require.NoError(t, os.MkdirAll(netDir, 0755))
+
+	for filename, content := range files {
+		path := filepath.Join(netDir, filename)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	return tempDir
+}
+
+func collectAndValidate(t *testing.T, collector *collectors.TCPCollector) *performance.TCPStats {
+	ctx := context.Background()
+	result, err := collector.Collect(ctx)
+	require.NoError(t, err)
+
+	stats, ok := result.(*performance.TCPStats)
+	require.True(t, ok, "expected *performance.TCPStats, got %T", result)
+	require.NotNil(t, stats.ConnectionsByState)
+
+	return stats
+}
+
+func TestTCPCollector_BasicFunctionality(t *testing.T) {
+	files := map[string]string{
+		"snmp":    validSNMPHeader,
+		"netstat": validNetstatHeader,
+		"tcp": validTCPHeader + `
+   0: 0100007F:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0277 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12346 1 0000000000000000 20 4 29 10 -1
+   2: 0100007F:0277 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12347 1 0000000000000000 20 4 29 10 -1
+   3: 0100007F:0277 0100007F:0050 06 00000000:00000000 00:00000000 00000000  1000        0 12348 1 0000000000000000 20 4 29 10 -1`,
+		"tcp6": validTCP6Header + `
+   0: 00000000000000000000000001000000:0050 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12349 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000001000000:0277 00000000000000000000000001000000:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12350 1 0000000000000000 20 4 29 10 -1`,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	// Verify SNMP stats
+	assert.Equal(t, uint64(100), stats.ActiveOpens)
+	assert.Equal(t, uint64(200), stats.PassiveOpens)
+	assert.Equal(t, uint64(10), stats.AttemptFails)
+	assert.Equal(t, uint64(5), stats.EstabResets)
+	assert.Equal(t, uint64(8), stats.CurrEstab)
+	assert.Equal(t, uint64(50000), stats.InSegs)
+	assert.Equal(t, uint64(40000), stats.OutSegs)
+	assert.Equal(t, uint64(500), stats.RetransSegs)
+	assert.Equal(t, uint64(2), stats.InErrs)
+	assert.Equal(t, uint64(15), stats.OutRsts)
+	assert.Equal(t, uint64(3), stats.InCsumErrors)
+
+	// Verify netstat extended stats
+	assert.Equal(t, uint64(10), stats.SyncookiesSent)
+	assert.Equal(t, uint64(5), stats.SyncookiesRecv)
+	assert.Equal(t, uint64(2), stats.SyncookiesFailed)
+	assert.Equal(t, uint64(20), stats.ListenOverflows)
+	assert.Equal(t, uint64(15), stats.ListenDrops)
+	assert.Equal(t, uint64(25), stats.TCPLostRetransmit)
+	assert.Equal(t, uint64(30), stats.TCPFastRetrans)
+	assert.Equal(t, uint64(35), stats.TCPSlowStartRetrans)
+	assert.Equal(t, uint64(40), stats.TCPTimeouts)
+
+	// Verify connection states (IPv4 + IPv6)
+	assert.Equal(t, uint64(3), stats.ConnectionsByState["ESTABLISHED"]) // 2 IPv4 + 1 IPv6
+	assert.Equal(t, uint64(2), stats.ConnectionsByState["LISTEN"])      // 1 IPv4 + 1 IPv6
+	assert.Equal(t, uint64(1), stats.ConnectionsByState["TIME_WAIT"])   // 1 IPv4
+}
+
+func TestTCPCollector_MinorFormatVariations(t *testing.T) {
+	// Test realistic format variations that might occur
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "trailing_newline_variations",
+			files: map[string]string{
+				"snmp": validSNMPHeader + "\n", // Extra newline at end
+			},
+		},
+		{
+			name: "no_trailing_newline",
+			files: map[string]string{
+				"snmp": strings.TrimSuffix(validSNMPHeader, "\n"), // No trailing newline
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+
+			// Basic validation that parsing worked
+			assert.Equal(t, uint64(100), stats.ActiveOpens)
+			assert.Equal(t, uint64(8), stats.CurrEstab)
+		})
+	}
+}
+
+func TestTCPCollector_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "missing_snmp_file",
+			files:       map[string]string{},
+			expectError: true,
+			errorMsg:    "failed to parse SNMP stats",
+		},
+		{
+			name: "malformed_snmp_header_value_mismatch",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens
+Tcp: 1 200 120000 -1 100 200 10 5 8`,
+			},
+			expectError: true,
+			errorMsg:    "header/value length mismatch",
+		},
+		{
+			name: "empty_snmp_file",
+			files: map[string]string{
+				"snmp": "",
+			},
+			expectError: true,
+			errorMsg:    "TCP statistics not found",
+		},
+		{
+			name: "no_tcp_section_in_snmp",
+			files: map[string]string{
+				"snmp": `Ip: Forwarding DefaultTTL
+Ip: 1 64`,
+			},
+			expectError: true,
+			errorMsg:    "TCP statistics not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+
+			ctx := context.Background()
+			_, err := collector.Collect(ctx)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTCPCollector_GracefulDegradation(t *testing.T) {
+	tests := []struct {
+		name           string
+		files          map[string]string
+		validateResult func(*testing.T, *performance.TCPStats)
+	}{
+		{
+			name: "missing_netstat_file",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP stats should be present
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				// Netstat stats should be zero
+				assert.Equal(t, uint64(0), stats.SyncookiesSent)
+				assert.Equal(t, uint64(0), stats.ListenOverflows)
+			},
+		},
+		{
+			name: "missing_tcp_files",
+			files: map[string]string{
+				"snmp":    validSNMPHeader,
+				"netstat": validNetstatHeader,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP and netstat stats should be present
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				assert.Equal(t, uint64(10), stats.SyncookiesSent)
+				// Connection states should be initialized but empty
+				assert.NotNil(t, stats.ConnectionsByState)
+				for _, state := range []string{"ESTABLISHED", "LISTEN", "TIME_WAIT"} {
+					assert.Equal(t, uint64(0), stats.ConnectionsByState[state])
+				}
+			},
+		},
+		{
+			name: "malformed_netstat_continues",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"netstat": `TcpExt: Field1 Field2
+TcpExt: NotANumber 456`,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP stats should still work
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				// Netstat parsing should have failed gracefully
+				assert.Equal(t, uint64(0), stats.SyncookiesSent)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+			tt.validateResult(t, stats)
+		})
+	}
+}
+
+func TestTCPCollector_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		check func(*testing.T, *performance.TCPStats)
+	}{
+		{
+			name: "extreme_values",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 18446744073709551615 18446744073709551615 0 0 0 0 0 0 0 0 0`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				assert.Equal(t, uint64(18446744073709551615), stats.ActiveOpens) // Max uint64
+				assert.Equal(t, uint64(18446744073709551615), stats.PassiveOpens)
+			},
+		},
+		{
+			name: "non_numeric_values_skipped",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 ABC 200 10 5 8 50000 40000 500 2 15 3`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				assert.Equal(t, uint64(0), stats.ActiveOpens) // Should be 0 due to parse error
+				assert.Equal(t, uint64(200), stats.PassiveOpens)
+			},
+		},
+		{
+			name: "unknown_tcp_states",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"tcp": validTCPHeader + `
+   0: 0100007F:0050 00000000:0000 FF 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0277 0100007F:0050 ZZ 00000000:00000000 00:00000000 00000000  1000        0 12346 1 0000000000000000 20 4 29 10 -1`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				// Unknown states should be ignored
+				assert.Equal(t, uint64(0), stats.ConnectionsByState["ESTABLISHED"])
+			},
+		},
+		{
+			name: "short_tcp_lines",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"tcp": validTCPHeader + `
+   0: 0100007F:0050
+   1: incomplete line`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				// Short lines should be skipped
+				for _, count := range stats.ConnectionsByState {
+					assert.Equal(t, uint64(0), count)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+			tt.check(t, stats)
+		})
+	}
+}
+
+func TestTCPCollector_AllConnectionStates(t *testing.T) {
+	// Test all possible TCP states
+	stateMap := map[string]string{
+		"01": "ESTABLISHED",
+		"02": "SYN_SENT",
+		"03": "SYN_RECV",
+		"04": "FIN_WAIT1",
+		"05": "FIN_WAIT2",
+		"06": "TIME_WAIT",
+		"07": "CLOSE",
+		"08": "CLOSE_WAIT",
+		"09": "LAST_ACK",
+		"0A": "LISTEN",
+		"0B": "CLOSING",
+	}
+
+	var tcpContent strings.Builder
+	tcpContent.WriteString(validTCPHeader + "\n")
+
+	// Create one connection for each state
+	i := 0
+	for hexState, _ := range stateMap {
+		line := fmt.Sprintf("  %2d: 0100007F:%04X 0100007F:0050 %s 00000000:00000000 00:00000000 00000000  1000        0 %d 1 0000000000000000 20 4 29 10 -1\n",
+			i, 0x1000+i, hexState, 12345+i)
+		tcpContent.WriteString(line)
+		i++
+	}
+
+	files := map[string]string{
+		"snmp": validSNMPHeader,
+		"tcp":  tcpContent.String(),
+		"tcp6": validTCP6Header,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	// Verify each state has exactly one connection
+	for hexState, stateName := range stateMap {
+		assert.Equal(t, uint64(1), stats.ConnectionsByState[stateName],
+			"State %s (%s) should have 1 connection", stateName, hexState)
+	}
+}
+
+func TestTCPCollector_LargeFiles(t *testing.T) {
+	// Test with many connections
+	var tcpContent strings.Builder
+	tcpContent.WriteString(validTCPHeader + "\n")
+
+	// Create 1000 connections
+	expectedEstablished := 1000
+	for i := 0; i < expectedEstablished; i++ {
+		line := fmt.Sprintf("  %2d: 0100007F:%04X 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 %d 1 0000000000000000 20 4 29 10 -1\n",
+			i, 0x1000+i, 12345+i)
+		tcpContent.WriteString(line)
+	}
+
+	files := map[string]string{
+		"snmp": validSNMPHeader,
+		"tcp":  tcpContent.String(),
+		"tcp6": validTCP6Header,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	assert.Equal(t, uint64(expectedEstablished), stats.ConnectionsByState["ESTABLISHED"])
+}

--- a/pkg/performance/types.go
+++ b/pkg/performance/types.go
@@ -248,31 +248,31 @@ type NetworkStats struct {
 // TCPStats represents TCP connection statistics
 type TCPStats struct {
 	// Connection counts from /proc/net/snmp (Tcp: line)
-	ActiveOpens  uint64 // Active connection openings
-	PassiveOpens uint64 // Passive connection openings
-	AttemptFails uint64 // Failed connection attempts
-	EstabResets  uint64 // Resets from established state
-	CurrEstab    uint64 // Current established connections
-	InSegs       uint64 // Segments received
-	OutSegs      uint64 // Segments sent
-	RetransSegs  uint64 // Segments retransmitted
-	InErrs       uint64 // Segments received with errors
-	OutRsts      uint64 // RST segments sent
-	InCsumErrors uint64 // Segments with checksum errors
+	ActiveOpens  uint64 // Active connection openings (count since boot)
+	PassiveOpens uint64 // Passive connection openings (count since boot)
+	AttemptFails uint64 // Failed connection attempts (count since boot)
+	EstabResets  uint64 // Resets from established state (count since boot)
+	CurrEstab    uint64 // Current established connections (instantaneous count)
+	InSegs       uint64 // Segments received (count since boot)
+	OutSegs      uint64 // Segments sent (count since boot)
+	RetransSegs  uint64 // Segments retransmitted (count since boot)
+	InErrs       uint64 // Segments received with errors (count since boot)
+	OutRsts      uint64 // RST segments sent (count since boot)
+	InCsumErrors uint64 // Segments with checksum errors (count since boot)
 	// Extended TCP stats from /proc/net/netstat (TcpExt: line)
-	SyncookiesSent      uint64 // SYN cookies sent
-	SyncookiesRecv      uint64 // SYN cookies received
-	SyncookiesFailed    uint64 // SYN cookies failed
-	ListenOverflows     uint64 // Listen queue overflows
-	ListenDrops         uint64 // Listen queue drops
-	TCPLostRetransmit   uint64 // Lost retransmissions
-	TCPFastRetrans      uint64 // Fast retransmissions
-	TCPSlowStartRetrans uint64 // Slow start retransmissions
-	TCPTimeouts         uint64 // TCP timeouts
+	SyncookiesSent      uint64 // SYN cookies sent (count since boot)
+	SyncookiesRecv      uint64 // SYN cookies received (count since boot)
+	SyncookiesFailed    uint64 // SYN cookies failed (count since boot)
+	ListenOverflows     uint64 // Listen queue overflows (count since boot)
+	ListenDrops         uint64 // Listen queue drops (count since boot)
+	TCPLostRetransmit   uint64 // Lost retransmissions (count since boot)
+	TCPFastRetrans      uint64 // Fast retransmissions (count since boot)
+	TCPSlowStartRetrans uint64 // Slow start retransmissions (count since boot)
+	TCPTimeouts         uint64 // TCP timeouts (count since boot)
 	// Connection states from /proc/net/tcp and /proc/net/tcp6
 	// States: ESTABLISHED, SYN_SENT, SYN_RECV, FIN_WAIT1, FIN_WAIT2,
 	// TIME_WAIT, CLOSE, CLOSE_WAIT, LAST_ACK, LISTEN, CLOSING
-	ConnectionsByState map[string]uint64
+	ConnectionsByState map[string]uint64 // Current count per state (instantaneous)
 }
 
 // KernelMessage represents a kernel log message from /dev/kmsg


### PR DESCRIPTION
## Summary
- Implements TCP collector for Netflix 60-second performance analysis methodology
- Collects TCP connection statistics and performance metrics from /proc/net files
- Provides raw counter values for delta calculations by consumers

## Implementation Details

### Data Sources
- `/proc/net/snmp` - Basic TCP statistics (RFC 1213 MIB-II)
- `/proc/net/netstat` - Extended Linux-specific TCP statistics
- `/proc/net/tcp` and `/proc/net/tcp6` - Connection state counts

### Key Features
- **Stateless collection** - Returns raw cumulative counters without delta calculations
- **Graceful degradation** - Continues if optional files are missing (netstat, tcp files)
- **IPv4 and IPv6 support** - Counts connections from both tcp and tcp6 files
- **No root required** - Reads world-readable proc files

### Metrics Collected
- Connection lifecycle counters (opens, failures, resets)
- Segment traffic (sent, received, retransmitted)
- Error counters (checksum errors, timeouts)
- SYN cookie statistics (DDoS protection metrics)
- Listen queue overflows
- Connection state distribution (ESTABLISHED, TIME_WAIT, etc.)

### Testing
- Comprehensive test suite following project testing guidelines
- Helper functions to reduce duplication
- Table-driven tests for systematic coverage
- Edge case and error handling tests
- Graceful degradation scenarios

## Test plan
- [x] Unit tests pass
- [x] Test coverage includes error cases and edge conditions
- [x] Verified collector returns raw counters (no delta calculations)
- [x] Tested graceful degradation when optional files missing

🤖 Generated with [Claude Code](https://claude.ai/code)