### PR TITLE
feat(disk): Add DiskCollector as point collector for disk I/O statistics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.6.0
 	github.com/go-logr/logr v1.4.2
 	github.com/gogo/protobuf v1.3.2
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.69.4
 	google.golang.org/protobuf v1.36.5
@@ -73,6 +74,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/pkg/performance/collector.go
+++ b/pkg/performance/collector.go
@@ -81,6 +81,10 @@ func (b *BaseCollector) Capabilities() CollectorCapabilities {
 	return b.capabilities
 }
 
+func (b *BaseCollector) Logger() logr.Logger {
+	return b.logger
+}
+
 type BaseContinuousCollector struct {
 	BaseCollector
 	status    CollectorStatus

--- a/pkg/performance/collectors/disk.go
+++ b/pkg/performance/collectors/disk.go
@@ -1,0 +1,227 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+)
+
+// Compile-time interface check
+var _ performance.Collector = (*DiskCollector)(nil)
+
+const (
+	// diskstatsFieldCount is the expected number of fields in /proc/diskstats
+	diskstatsFieldCount = 14
+)
+
+// DiskCollector collects disk I/O statistics from /proc/diskstats
+//
+// This collector reads the kernel's disk statistics interface to provide raw counter values:
+// - Read/write operations completed
+// - Sectors read/written
+// - Time spent on I/O operations
+// - Queue statistics
+//
+// Only whole disk devices are reported; partitions are filtered out.
+// All values are cumulative counters since system boot.
+type DiskCollector struct {
+	performance.BaseCollector
+	diskstatsPath string
+}
+
+func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) *DiskCollector {
+	capabilities := performance.CollectorCapabilities{
+		SupportsOneShot:    true,
+		SupportsContinuous: false,
+		RequiresRoot:       false,
+		RequiresEBPF:       false,
+		MinKernelVersion:   "2.6.0", // /proc/diskstats has been around since 2.6
+	}
+
+	return &DiskCollector{
+		BaseCollector: performance.NewBaseCollector(
+			performance.MetricTypeDisk,
+			"Disk I/O Statistics Collector",
+			logger,
+			config,
+			capabilities,
+		),
+		diskstatsPath: filepath.Join(config.HostProcPath, "diskstats"),
+	}
+}
+
+// Collect performs a one-shot collection of disk statistics
+func (c *DiskCollector) Collect(ctx context.Context) (any, error) {
+	stats, err := c.collectDiskStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect disk stats: %w", err)
+	}
+
+	c.Logger().V(1).Info("Collected disk statistics", "devices", len(stats))
+	return stats, nil
+}
+
+// collectDiskStats reads and parses /proc/diskstats
+//
+// Format: major minor device reads... writes... ios_in_progress io_time weighted_io_time
+// Fields 4-14 are I/O statistics. Sectors are 512 bytes, times in milliseconds.
+//
+// Reference: https://www.kernel.org/doc/Documentation/iostats.txt
+func (c *DiskCollector) collectDiskStats() ([]*performance.DiskStats, error) {
+	file, err := os.Open(c.diskstatsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", c.diskstatsPath, err)
+	}
+	defer file.Close()
+
+	var diskStats []*performance.DiskStats
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		// /proc/diskstats has 14 fields (3 identification + 11 metrics)
+		if len(fields) < diskstatsFieldCount {
+			continue
+		}
+
+		// Parse fields
+		major, err := strconv.ParseUint(fields[0], 10, 32)
+		if err != nil {
+			c.Logger().V(1).Info("Failed to parse disk major number",
+				"line", line, "error", err)
+			continue
+		}
+
+		minor, err := strconv.ParseUint(fields[1], 10, 32)
+		if err != nil {
+			c.Logger().V(1).Info("Failed to parse disk minor number",
+				"line", line, "error", err)
+			continue
+		}
+
+		device := fields[2]
+
+		// Skip partitions - only include whole disks
+		if IsPartition(device) {
+			continue
+		}
+
+		stats := &performance.DiskStats{
+			Device: device,
+			Major:  uint32(major),
+			Minor:  uint32(minor),
+		}
+
+		// Parse read statistics (fields 4-7)
+		parseErrors := false
+
+		if stats.ReadsCompleted, err = strconv.ParseUint(fields[3], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.ReadsMerged, err = strconv.ParseUint(fields[4], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.SectorsRead, err = strconv.ParseUint(fields[5], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.ReadTime, err = strconv.ParseUint(fields[6], 10, 64); err != nil {
+			parseErrors = true
+		}
+
+		// Parse write statistics (fields 8-11)
+		if stats.WritesCompleted, err = strconv.ParseUint(fields[7], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.WritesMerged, err = strconv.ParseUint(fields[8], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.SectorsWritten, err = strconv.ParseUint(fields[9], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.WriteTime, err = strconv.ParseUint(fields[10], 10, 64); err != nil {
+			parseErrors = true
+		}
+
+		// Parse I/O queue statistics (fields 12-14)
+		if stats.IOsInProgress, err = strconv.ParseUint(fields[11], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.IOTime, err = strconv.ParseUint(fields[12], 10, 64); err != nil {
+			parseErrors = true
+		}
+		if stats.WeightedIOTime, err = strconv.ParseUint(fields[13], 10, 64); err != nil {
+			parseErrors = true
+		}
+
+		if parseErrors {
+			c.Logger().V(2).Info("Parse errors in disk statistics",
+				"device", device, "line", line)
+		}
+
+		diskStats = append(diskStats, stats)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", c.diskstatsPath, err)
+	}
+
+	c.Logger().V(1).Info("Collected disk statistics", "devices", len(diskStats))
+	return diskStats, nil
+}
+
+// IsPartition checks if a device name represents a partition
+//
+// Partitions are identified by:
+// - Standard devices: end with a digit (e.g., sda1, vdb2)
+// - NVMe devices: contain 'pN' suffix (e.g., nvme0n1p1)
+// - MMC devices: contain 'pN' suffix (e.g., mmcblk0p1)
+//
+// Special cases:
+// - loop devices (loop0, loop1) are whole devices, not partitions
+// - device mapper devices (dm-0, dm-1) are whole devices, not partitions
+func IsPartition(device string) bool {
+	if device == "" {
+		return false
+	}
+
+	// Special whole devices that end with digits
+	if strings.HasPrefix(device, "loop") || strings.HasPrefix(device, "dm-") {
+		return false
+	}
+
+	// NVMe and MMC devices use 'p' before partition number
+	if strings.Contains(device, "nvme") || strings.Contains(device, "mmcblk") {
+		// Look for 'p' followed by digits at the end
+		idx := strings.LastIndex(device, "p")
+		if idx > 0 && idx < len(device)-1 {
+			// Check if everything after 'p' is digits
+			partNum := device[idx+1:]
+			for _, ch := range partNum {
+				if ch < '0' || ch > '9' {
+					return false
+				}
+			}
+			return true
+		}
+		return false
+	}
+
+	// Standard devices: partition if ends with digit
+	lastChar := device[len(device)-1]
+	return lastChar >= '0' && lastChar <= '9'
+}

--- a/pkg/performance/collectors/disk_test.go
+++ b/pkg/performance/collectors/disk_test.go
@@ -1,0 +1,414 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/antimetal/agent/pkg/performance/collectors"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test data constants for realistic /proc/diskstats content
+const (
+	// Valid diskstats with various device types
+	validDiskstats = `   8       0 sda 1234 567 890123 4567 890 123 456789 1234 0 5678 9012
+   8       1 sda1 100 50 20000 100 50 25 10000 50 0 150 200
+   8       2 sda2 200 100 40000 200 100 50 20000 100 0 300 400
+   8      16 sdb 2345 678 901234 5678 901 234 567890 2345 1 6789 10123
+ 259       0 nvme0n1 3456 789 1234567 6789 1234 567 890123 3456 2 7890 11234
+ 259       1 nvme0n1p1 300 150 60000 300 150 75 30000 150 0 450 600
+ 179       0 mmcblk0 4567 890 2345678 7890 2345 678 901234 4567 3 8901 12345
+ 179       1 mmcblk0p1 400 200 80000 400 200 100 40000 200 0 600 800
+   7       0 loop0 10 0 100 5 0 0 0 0 0 5 5
+ 253       0 dm-0 1000 200 300000 1500 500 100 200000 800 0 2000 2500`
+
+	// Minimal valid diskstats
+	minimalDiskstats = `   8       0 sda 0 0 0 0 0 0 0 0 0 0 0`
+
+	// Edge case with maximum values
+	maxValuesDiskstats = `   8       0 sda 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615`
+
+	// Malformed data scenarios
+	malformedShortLine = `   8       0 sda incomplete line`
+	malformedBadMajor  = `   not_a_number 0 sda 1234 567 890123 4567 890 123 456789 1234 0 5678 9012`
+	malformedBadMinor  = `   8 not_a_number sda 1234 567 890123 4567 890 123 456789 1234 0 5678 9012`
+	malformedBadStats  = `   8       0 sda abc def ghi jkl mno pqr stu vwx 0 yz 123`
+)
+
+// Helper functions following TCP collector patterns
+func createDiskCollector(t *testing.T, procPath string) *collectors.DiskCollector {
+	config := performance.CollectionConfig{
+		HostProcPath: procPath,
+	}
+	return collectors.NewDiskCollector(logr.Discard(), config)
+}
+
+func setupDiskstatsFile(t *testing.T, content string) string {
+	tempDir := t.TempDir()
+	diskstatsPath := filepath.Join(tempDir, "diskstats")
+	require.NoError(t, os.WriteFile(diskstatsPath, []byte(content), 0644))
+	return tempDir
+}
+
+func collectDiskStats(t *testing.T, collector *collectors.DiskCollector) []*performance.DiskStats {
+	ctx := context.Background()
+	result, err := collector.Collect(ctx)
+	require.NoError(t, err)
+
+	stats, ok := result.([]*performance.DiskStats)
+	require.True(t, ok, "expected []*performance.DiskStats, got %T", result)
+	return stats
+}
+
+func collectDiskStatsWithError(t *testing.T, collector *collectors.DiskCollector) error {
+	ctx := context.Background()
+	_, err := collector.Collect(ctx)
+	return err
+}
+
+// Test basic functionality
+func TestDiskCollector_BasicFunctionality(t *testing.T) {
+	procPath := setupDiskstatsFile(t, validDiskstats)
+	collector := createDiskCollector(t, procPath)
+
+	stats := collectDiskStats(t, collector)
+
+	// Should have 6 whole disks (partitions filtered out)
+	assert.Equal(t, 6, len(stats))
+
+	// Create map for easier validation
+	diskMap := make(map[string]*performance.DiskStats)
+	for _, stat := range stats {
+		diskMap[stat.Device] = stat
+	}
+
+	// Verify whole disks are included
+	for _, device := range []string{"sda", "sdb", "nvme0n1", "mmcblk0", "loop0", "dm-0"} {
+		assert.Contains(t, diskMap, device, "device %s should be present", device)
+	}
+
+	// Verify partitions are filtered out
+	for _, partition := range []string{"sda1", "sda2", "nvme0n1p1", "mmcblk0p1"} {
+		assert.NotContains(t, diskMap, partition, "partition %s should be filtered", partition)
+	}
+
+	// Validate specific disk values
+	sda := diskMap["sda"]
+	assert.Equal(t, uint32(8), sda.Major)
+	assert.Equal(t, uint32(0), sda.Minor)
+	assert.Equal(t, uint64(1234), sda.ReadsCompleted)
+	assert.Equal(t, uint64(567), sda.ReadsMerged)
+	assert.Equal(t, uint64(890123), sda.SectorsRead)
+	assert.Equal(t, uint64(4567), sda.ReadTime)
+	assert.Equal(t, uint64(890), sda.WritesCompleted)
+	assert.Equal(t, uint64(123), sda.WritesMerged)
+	assert.Equal(t, uint64(456789), sda.SectorsWritten)
+	assert.Equal(t, uint64(1234), sda.WriteTime)
+	assert.Equal(t, uint64(0), sda.IOsInProgress)
+	assert.Equal(t, uint64(5678), sda.IOTime)
+	assert.Equal(t, uint64(9012), sda.WeightedIOTime)
+
+	// Verify rate fields are zero (not calculated in point collector)
+	assert.Equal(t, float64(0), sda.IOPS)
+	assert.Equal(t, float64(0), sda.ReadBytesPerSec)
+	assert.Equal(t, float64(0), sda.WriteBytesPerSec)
+	assert.Equal(t, float64(0), sda.Utilization)
+	assert.Equal(t, float64(0), sda.AvgQueueSize)
+	assert.Equal(t, float64(0), sda.AvgReadLatency)
+	assert.Equal(t, float64(0), sda.AvgWriteLatency)
+}
+
+// Test error handling
+func TestDiskCollector_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupFunc func() string
+		errorMsg  string
+	}{
+		{
+			name: "missing_diskstats_file",
+			setupFunc: func() string {
+				return t.TempDir() // Empty directory
+			},
+			errorMsg: "failed to open",
+		},
+		{
+			name: "unreadable_directory",
+			setupFunc: func() string {
+				return "/non/existent/path"
+			},
+			errorMsg: "failed to open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := tt.setupFunc()
+			collector := createDiskCollector(t, procPath)
+			err := collectDiskStatsWithError(t, collector)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorMsg)
+		})
+	}
+}
+
+// Test graceful degradation with malformed data
+func TestDiskCollector_GracefulDegradation(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		validateResult func(*testing.T, []*performance.DiskStats)
+	}{
+		{
+			name:    "empty_file",
+			content: "",
+			validateResult: func(t *testing.T, stats []*performance.DiskStats) {
+				assert.Empty(t, stats)
+			},
+		},
+		{
+			name:    "only_partitions",
+			content: "   8       1 sda1 100 50 20000 100 50 25 10000 50 0 150 200\n   8       2 sda2 200 100 40000 200 100 50 20000 100 0 300 400",
+			validateResult: func(t *testing.T, stats []*performance.DiskStats) {
+				assert.Empty(t, stats, "all partitions should be filtered")
+			},
+		},
+		{
+			name:    "mixed_valid_and_invalid",
+			content: validDiskstats + "\n" + malformedShortLine + "\n" + malformedBadMajor,
+			validateResult: func(t *testing.T, stats []*performance.DiskStats) {
+				// Should still parse the valid lines
+				assert.Equal(t, 6, len(stats))
+			},
+		},
+		{
+			name:    "short_lines_skipped",
+			content: malformedShortLine + "\n" + minimalDiskstats,
+			validateResult: func(t *testing.T, stats []*performance.DiskStats) {
+				// Should skip short line but parse minimal valid line
+				assert.Equal(t, 1, len(stats))
+				assert.Equal(t, "sda", stats[0].Device)
+			},
+		},
+		{
+			name:    "bad_numeric_fields",
+			content: malformedBadStats + "\n" + "   253       0 dm-0 1000 200 300000 1500 500 100 200000 800 0 2000 2500",
+			validateResult: func(t *testing.T, stats []*performance.DiskStats) {
+				// Should include device with parse errors (zero values) and valid device
+				assert.Equal(t, 2, len(stats))
+
+				// Find sda with bad stats
+				var sda *performance.DiskStats
+				for _, s := range stats {
+					if s.Device == "sda" {
+						sda = s
+						break
+					}
+				}
+				require.NotNil(t, sda)
+				// All numeric fields should be zero due to parse errors
+				assert.Equal(t, uint64(0), sda.ReadsCompleted)
+				assert.Equal(t, uint64(0), sda.SectorsRead)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupDiskstatsFile(t, tt.content)
+			collector := createDiskCollector(t, procPath)
+			stats := collectDiskStats(t, collector)
+			tt.validateResult(t, stats)
+		})
+	}
+}
+
+// Test edge cases
+func TestDiskCollector_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		check   func(*testing.T, []*performance.DiskStats)
+	}{
+		{
+			name:    "extreme_values",
+			content: maxValuesDiskstats,
+			check: func(t *testing.T, stats []*performance.DiskStats) {
+				assert.Equal(t, 1, len(stats))
+				sda := stats[0]
+				// Verify max uint64 values are parsed correctly
+				assert.Equal(t, uint64(18446744073709551615), sda.ReadsCompleted)
+				assert.Equal(t, uint64(18446744073709551615), sda.SectorsRead)
+				assert.Equal(t, uint64(18446744073709551615), sda.WritesCompleted)
+			},
+		},
+		{
+			name:    "zero_values",
+			content: minimalDiskstats,
+			check: func(t *testing.T, stats []*performance.DiskStats) {
+				assert.Equal(t, 1, len(stats))
+				sda := stats[0]
+				assert.Equal(t, uint64(0), sda.ReadsCompleted)
+				assert.Equal(t, uint64(0), sda.SectorsRead)
+				assert.Equal(t, uint64(0), sda.WritesCompleted)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupDiskstatsFile(t, tt.content)
+			collector := createDiskCollector(t, procPath)
+			stats := collectDiskStats(t, collector)
+			tt.check(t, stats)
+		})
+	}
+}
+
+// Test device type detection
+func TestDiskCollector_DeviceTypes(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		expectedDevices []string
+		filteredDevices []string
+	}{
+		{
+			name: "standard_scsi_devices",
+			content: `   8       0 sda 1 2 3 4 5 6 7 8 9 10 11
+   8       1 sda1 1 2 3 4 5 6 7 8 9 10 11
+   8      16 sdb 1 2 3 4 5 6 7 8 9 10 11
+   8      17 sdb1 1 2 3 4 5 6 7 8 9 10 11`,
+			expectedDevices: []string{"sda", "sdb"},
+			filteredDevices: []string{"sda1", "sdb1"},
+		},
+		{
+			name: "nvme_devices",
+			content: ` 259       0 nvme0n1 1 2 3 4 5 6 7 8 9 10 11
+ 259       1 nvme0n1p1 1 2 3 4 5 6 7 8 9 10 11
+ 259       2 nvme0n1p2 1 2 3 4 5 6 7 8 9 10 11`,
+			expectedDevices: []string{"nvme0n1"},
+			filteredDevices: []string{"nvme0n1p1", "nvme0n1p2"},
+		},
+		{
+			name: "mmc_devices",
+			content: ` 179       0 mmcblk0 1 2 3 4 5 6 7 8 9 10 11
+ 179       1 mmcblk0p1 1 2 3 4 5 6 7 8 9 10 11
+ 179       2 mmcblk0p2 1 2 3 4 5 6 7 8 9 10 11`,
+			expectedDevices: []string{"mmcblk0"},
+			filteredDevices: []string{"mmcblk0p1", "mmcblk0p2"},
+		},
+		{
+			name: "special_devices",
+			content: `   7       0 loop0 1 2 3 4 5 6 7 8 9 10 11
+   7       1 loop1 1 2 3 4 5 6 7 8 9 10 11
+   7      10 loop10 1 2 3 4 5 6 7 8 9 10 11
+ 253       0 dm-0 1 2 3 4 5 6 7 8 9 10 11
+ 253       1 dm-1 1 2 3 4 5 6 7 8 9 10 11`,
+			expectedDevices: []string{"loop0", "loop1", "loop10", "dm-0", "dm-1"},
+			filteredDevices: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupDiskstatsFile(t, tt.content)
+			collector := createDiskCollector(t, procPath)
+			stats := collectDiskStats(t, collector)
+
+			// Verify expected devices are present
+			deviceMap := make(map[string]bool)
+			for _, stat := range stats {
+				deviceMap[stat.Device] = true
+			}
+
+			for _, expected := range tt.expectedDevices {
+				assert.True(t, deviceMap[expected], "expected device %s not found", expected)
+			}
+
+			// Verify filtered devices are not present
+			for _, filtered := range tt.filteredDevices {
+				assert.False(t, deviceMap[filtered], "partition %s should be filtered", filtered)
+			}
+
+			assert.Equal(t, len(tt.expectedDevices), len(stats))
+		})
+	}
+}
+
+// Test isPartition function directly
+func TestIsPartition(t *testing.T) {
+	tests := []struct {
+		device      string
+		isPartition bool
+	}{
+		// Whole disks - standard
+		{"sda", false},
+		{"sdb", false},
+		{"vda", false},
+		{"hda", false},
+		{"xvda", false},
+
+		// Whole disks - NVMe
+		{"nvme0n1", false},
+		{"nvme1n1", false},
+		{"nvme10n1", false},
+
+		// Whole disks - MMC
+		{"mmcblk0", false},
+		{"mmcblk1", false},
+		{"mmcblk10", false},
+
+		// Whole disks - special
+		{"loop0", false},
+		{"loop1", false},
+		{"loop10", false},
+		{"dm-0", false},
+		{"dm-1", false},
+		{"dm-10", false},
+
+		// Partitions - standard
+		{"sda1", true},
+		{"sda2", true},
+		{"sdb10", true},
+		{"vda1", true},
+		{"hda3", true},
+		{"xvda1", true},
+
+		// Partitions - NVMe
+		{"nvme0n1p1", true},
+		{"nvme0n1p2", true},
+		{"nvme1n1p10", true},
+
+		// Partitions - MMC
+		{"mmcblk0p1", true},
+		{"mmcblk0p2", true},
+		{"mmcblk1p5", true},
+
+		// Edge cases
+		{"", false},
+		{"sd", false},
+		{"nvme", false},
+		{"mmcblk", false},
+		{"loopback", false},
+		{"dm-", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.device, func(t *testing.T) {
+			result := collectors.IsPartition(tt.device)
+			assert.Equal(t, tt.isPartition, result, "device: %s", tt.device)
+		})
+	}
+}

--- a/pkg/performance/collectors/load.go
+++ b/pkg/performance/collectors/load.go
@@ -19,7 +19,8 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// LoadCollector collects system load statistics from /proc/loadavg
+// LoadCollector collects system load statistics from /proc/loadavg and /proc/uptime
+// Reference: https://www.kernel.org/doc/html/latest/filesystems/proc.html#proc-loadavg
 type LoadCollector struct {
 	performance.BaseCollector
 	loadavgPath string
@@ -53,12 +54,23 @@ func (c *LoadCollector) Collect(ctx context.Context) (any, error) {
 }
 
 // collectLoadStats reads and parses /proc/loadavg and /proc/uptime
+//
+// Error Handling Strategy:
+// - /proc/loadavg: Any parsing error returns an error (critical data)
+// - /proc/uptime: Parsing errors are logged but don't fail collection (optional data)
+//
+// This design ensures the collector works in containerized environments where
+// uptime may not be available while still providing essential load metrics.
+//
+// File formats:
+// - /proc/loadavg: load1 load5 load15 nr_running/nr_threads last_pid
+// - /proc/uptime: uptime_seconds idle_seconds
+//
+// Reference: https://www.kernel.org/doc/html/latest/filesystems/proc.html
 func (c *LoadCollector) collectLoadStats() (*performance.LoadStats, error) {
 	stats := &performance.LoadStats{}
 
-	// Read /proc/loadavg
-	// Format: 0.00 0.01 0.05 1/234 5678
-	// Where: 1min 5min 15min running/total lastpid
+	// Read /proc/loadavg - critical data, any error fails the collection
 	loadavgData, err := os.ReadFile(c.loadavgPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", c.loadavgPath, err)
@@ -66,60 +78,73 @@ func (c *LoadCollector) collectLoadStats() (*performance.LoadStats, error) {
 
 	fields := strings.Fields(string(loadavgData))
 	if len(fields) < 5 {
-		return nil, fmt.Errorf("unexpected format in %s: %s", c.loadavgPath, string(loadavgData))
+		return nil, fmt.Errorf("unexpected format in %s: got %d fields, expected 5 (load1 load5 load15 running/total lastpid): %q",
+			c.loadavgPath, len(fields), strings.TrimSpace(string(loadavgData)))
 	}
 
 	// Parse load averages
 	if stats.Load1Min, err = strconv.ParseFloat(fields[0], 64); err != nil {
-		return nil, fmt.Errorf("failed to parse 1min load: %w", err)
+		return nil, fmt.Errorf("failed to parse 1min load average from %q: %w", fields[0], err)
 	}
 
 	if stats.Load5Min, err = strconv.ParseFloat(fields[1], 64); err != nil {
-		return nil, fmt.Errorf("failed to parse 5min load: %w", err)
+		return nil, fmt.Errorf("failed to parse 5min load average from %q: %w", fields[1], err)
 	}
 
 	if stats.Load15Min, err = strconv.ParseFloat(fields[2], 64); err != nil {
-		return nil, fmt.Errorf("failed to parse 15min load: %w", err)
+		return nil, fmt.Errorf("failed to parse 15min load average from %q: %w", fields[2], err)
 	}
 
 	// Parse running/total processes
 	procParts := strings.Split(fields[3], "/")
 	if len(procParts) != 2 {
-		return nil, fmt.Errorf("unexpected process format: %s", fields[3])
+		return nil, fmt.Errorf("unexpected process count format: expected 'running/total', got %q", fields[3])
 	}
 
 	running, err := strconv.ParseInt(procParts[0], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse running processes: %w", err)
+		return nil, fmt.Errorf("failed to parse running process count from %q: %w", procParts[0], err)
 	}
 	stats.RunningProcs = int32(running)
 
 	total, err := strconv.ParseInt(procParts[1], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse total processes: %w", err)
+		return nil, fmt.Errorf("failed to parse total process count from %q: %w", procParts[1], err)
 	}
 	stats.TotalProcs = int32(total)
 
 	// Parse last PID
 	lastPID, err := strconv.ParseInt(fields[4], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse last PID: %w", err)
+		return nil, fmt.Errorf("failed to parse last PID from %q: %w", fields[4], err)
 	}
 	stats.LastPID = int32(lastPID)
 
-	// Read /proc/uptime for system uptime
-	// Format: uptime_seconds idle_seconds
+	// Read /proc/uptime for system uptime - optional data, errors are logged but don't fail collection
+	// Format: "uptime_seconds idle_seconds" - kernel always provides exactly 2 fields
+	// Reference: https://github.com/torvalds/linux/blob/master/fs/proc/uptime.c
+	//
+	// Graceful degradation rationale:
+	// - Uptime is supplementary information, not critical for load monitoring
+	// - Some containerized environments may not provide /proc/uptime
+	// - Load averages and process counts are the essential metrics
 	uptimeData, err := os.ReadFile(c.uptimePath)
-	if err == nil {
+	if err != nil {
+		c.Logger().V(2).Info("Failed to read uptime file (continuing without uptime)", "path", c.uptimePath, "error", err)
+	} else {
 		uptimeFields := strings.Fields(string(uptimeData))
-		if len(uptimeFields) >= 1 {
+		if len(uptimeFields) != 2 {
+			c.Logger().V(2).Info("Unexpected uptime format - expected 2 fields (continuing with zero uptime)", "path", c.uptimePath,
+				"fields", len(uptimeFields), "content", strings.TrimSpace(string(uptimeData)))
+		} else {
 			uptimeSeconds, err := strconv.ParseFloat(uptimeFields[0], 64)
-			if err == nil {
+			if err != nil {
+				c.Logger().V(2).Info("Failed to parse uptime (continuing with zero uptime)", "value", uptimeFields[0], "error", err)
+			} else {
 				stats.Uptime = time.Duration(uptimeSeconds * float64(time.Second))
 			}
 		}
 	}
-	// If we can't read uptime, just continue without it
 
 	return stats, nil
 }

--- a/pkg/performance/collectors/load_test.go
+++ b/pkg/performance/collectors/load_test.go
@@ -1,3 +1,9 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package collectors
 
 import (

--- a/pkg/performance/collectors/load_test.go
+++ b/pkg/performance/collectors/load_test.go
@@ -1,0 +1,360 @@
+package collectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Valid scenarios
+	validLoadavgContent    = "0.50 1.25 2.75 2/1234 12345"
+	validUptimeContent     = "1234.56 5678.90"
+	extraWhitespaceContent = "  0.50   1.25   2.75   2/1234   12345  "
+
+	// Boundary conditions
+	highLoadContent = "15.80 10.45 8.32 5/2048 98765"
+	zeroLoadContent = "0.00 0.00 0.00 1/100 1"
+
+	// Error conditions
+	malformedLoadContent = "0.50 1.25"
+	invalidFloatContent  = "invalid 1.25 2.75 2/1234 12345"
+	invalidProcContent   = "0.50 1.25 2.75 invalid_procs 12345"
+	invalidPIDContent    = "0.50 1.25 2.75 2/1234 invalid_pid"
+	whitespaceContent    = "   \n   \t   "
+)
+
+func createTestCollector(t *testing.T, loadavgContent, uptimeContent string) *LoadCollector {
+	tmpDir := t.TempDir()
+
+	if loadavgContent != "" {
+		loadavgPath := filepath.Join(tmpDir, "loadavg")
+		err := os.WriteFile(loadavgPath, []byte(loadavgContent), 0644)
+		require.NoError(t, err)
+	}
+
+	if uptimeContent != "" {
+		uptimePath := filepath.Join(tmpDir, "uptime")
+		err := os.WriteFile(uptimePath, []byte(uptimeContent), 0644)
+		require.NoError(t, err)
+	}
+
+	config := performance.CollectionConfig{
+		HostProcPath: tmpDir,
+	}
+	return NewLoadCollector(logr.Discard(), config)
+}
+
+func validateCollectorInterface(t *testing.T, collector interface{}) {
+	_, ok := collector.(performance.Collector)
+	require.True(t, ok, "collector must implement Collector interface")
+}
+
+func validateLoadStats(t *testing.T, stats *performance.LoadStats, expected *performance.LoadStats) {
+	assert.Equal(t, expected.Load1Min, stats.Load1Min)
+	assert.Equal(t, expected.Load5Min, stats.Load5Min)
+	assert.Equal(t, expected.Load15Min, stats.Load15Min)
+	assert.Equal(t, expected.RunningProcs, stats.RunningProcs)
+	assert.Equal(t, expected.TotalProcs, stats.TotalProcs)
+	assert.Equal(t, expected.LastPID, stats.LastPID)
+	if expected.Uptime != 0 {
+		assert.Equal(t, expected.Uptime, stats.Uptime)
+	}
+}
+
+func collectAndValidate(t *testing.T, collector *LoadCollector, wantErr bool) *performance.LoadStats {
+	result, err := collector.Collect(context.Background())
+
+	if wantErr {
+		assert.Error(t, err)
+		return nil
+	}
+
+	require.NoError(t, err)
+	stats, ok := result.(*performance.LoadStats)
+	require.True(t, ok)
+	return stats
+}
+
+func TestLoadCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name               string
+		hostProcPath       string
+		expectedLoadPath   string
+		expectedUptimePath string
+	}{
+		{"default proc path", "/proc", "/proc/loadavg", "/proc/uptime"},
+		{"custom proc path", "/custom/proc", "/custom/proc/loadavg", "/custom/proc/uptime"},
+		{"empty proc path", "", "loadavg", "uptime"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := performance.CollectionConfig{HostProcPath: tt.hostProcPath}
+			collector := NewLoadCollector(logr.Discard(), config)
+
+			validateCollectorInterface(t, collector)
+			assert.Equal(t, tt.expectedLoadPath, collector.loadavgPath)
+			assert.Equal(t, tt.expectedUptimePath, collector.uptimePath)
+		})
+	}
+}
+
+func TestLoadCollector_MissingFiles(t *testing.T) {
+	tests := []struct {
+		name              string
+		createLoadavg     bool
+		createUptime      bool
+		wantErr           bool
+		expectedErr       string
+		useNonExistentDir bool
+	}{
+		{
+			name:          "missing loadavg file",
+			createLoadavg: false,
+			createUptime:  true,
+			wantErr:       true,
+			expectedErr:   "failed to read",
+		},
+		{
+			name:          "missing uptime file (graceful degradation)",
+			createLoadavg: true,
+			createUptime:  false,
+			wantErr:       false,
+		},
+		{
+			name:          "missing both files",
+			createLoadavg: false,
+			createUptime:  false,
+			wantErr:       true,
+			expectedErr:   "failed to read",
+		},
+		{
+			name:              "non-existent directory",
+			useNonExistentDir: true,
+			wantErr:           true,
+			expectedErr:       "failed to read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var collector *LoadCollector
+			if tt.useNonExistentDir {
+				config := performance.CollectionConfig{HostProcPath: "/non/existent/path"}
+				collector = NewLoadCollector(logr.Discard(), config)
+			} else {
+				loadavgContent := ""
+				uptimeContent := ""
+				if tt.createLoadavg {
+					loadavgContent = validLoadavgContent
+				}
+				if tt.createUptime {
+					uptimeContent = validUptimeContent
+				}
+				collector = createTestCollector(t, loadavgContent, uptimeContent)
+			}
+
+			result, err := collector.Collect(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			stats, ok := result.(*performance.LoadStats)
+			require.True(t, ok)
+
+			// For missing uptime case, should have zero uptime but valid load data
+			if !tt.createUptime && tt.createLoadavg {
+				assert.Equal(t, 0.50, stats.Load1Min)
+				assert.Equal(t, time.Duration(0), stats.Uptime)
+			}
+		})
+	}
+}
+
+func TestLoadCollector_DataParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		loadavgContent string
+		uptimeContent  string
+		wantErr        bool
+		expectedErr    string
+		expected       *performance.LoadStats
+	}{
+		// Valid parsing cases
+		{
+			name:           "valid load stats with uptime",
+			loadavgContent: validLoadavgContent,
+			uptimeContent:  validUptimeContent,
+			expected: &performance.LoadStats{
+				Load1Min:     0.50,
+				Load5Min:     1.25,
+				Load15Min:    2.75,
+				RunningProcs: 2,
+				TotalProcs:   1234,
+				LastPID:      12345,
+				Uptime:       time.Duration(1234.56 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "high load values",
+			loadavgContent: highLoadContent,
+			uptimeContent:  "86400.25 172800.50",
+			expected: &performance.LoadStats{
+				Load1Min:     15.80,
+				Load5Min:     10.45,
+				Load15Min:    8.32,
+				RunningProcs: 5,
+				TotalProcs:   2048,
+				LastPID:      98765,
+				Uptime:       time.Duration(86400.25 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "zero load values",
+			loadavgContent: zeroLoadContent,
+			uptimeContent:  "0.01 0.02",
+			expected: &performance.LoadStats{
+				Load1Min:     0.00,
+				Load5Min:     0.00,
+				Load15Min:    0.00,
+				RunningProcs: 1,
+				TotalProcs:   100,
+				LastPID:      1,
+				Uptime:       time.Duration(0.01 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "very large load values",
+			loadavgContent: "999.99 888.88 777.77 9999/99999 999999",
+			uptimeContent:  "999999.99 1999999.98",
+			expected: &performance.LoadStats{
+				Load1Min:     999.99,
+				Load5Min:     888.88,
+				Load15Min:    777.77,
+				RunningProcs: 9999,
+				TotalProcs:   99999,
+				LastPID:      999999,
+				Uptime:       time.Duration(999999.99 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "single digit process counts",
+			loadavgContent: "0.01 0.02 0.03 1/1 1",
+			uptimeContent:  "1.00 2.00",
+			expected: &performance.LoadStats{
+				Load1Min:     0.01,
+				Load5Min:     0.02,
+				Load15Min:    0.03,
+				RunningProcs: 1,
+				TotalProcs:   1,
+				LastPID:      1,
+				Uptime:       time.Duration(1.00 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "extra whitespace in loadavg",
+			loadavgContent: extraWhitespaceContent,
+			uptimeContent:  "  1234.56   5678.90  ",
+			expected: &performance.LoadStats{
+				Load1Min:     0.50,
+				Load5Min:     1.25,
+				Load15Min:    2.75,
+				RunningProcs: 2,
+				TotalProcs:   1234,
+				LastPID:      12345,
+				Uptime:       time.Duration(1234.56 * float64(time.Second)),
+			},
+		},
+		{
+			name:           "empty uptime (graceful degradation)",
+			loadavgContent: validLoadavgContent,
+			uptimeContent:  "",
+			expected: &performance.LoadStats{
+				Load1Min:     0.50,
+				Load5Min:     1.25,
+				Load15Min:    2.75,
+				RunningProcs: 2,
+				TotalProcs:   1234,
+				LastPID:      12345,
+				Uptime:       time.Duration(0),
+			},
+		},
+		// Error cases - loadavg parsing errors
+		{
+			name:           "malformed loadavg - insufficient fields",
+			loadavgContent: malformedLoadContent,
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "got 2 fields, expected 5",
+		},
+		{
+			name:           "malformed loadavg - invalid float",
+			loadavgContent: invalidFloatContent,
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "invalid syntax",
+		},
+		{
+			name:           "malformed loadavg - invalid process count format",
+			loadavgContent: invalidProcContent,
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "unexpected process count format",
+		},
+		{
+			name:           "malformed loadavg - invalid PID",
+			loadavgContent: invalidPIDContent,
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "invalid syntax",
+		},
+		{
+			name:           "empty loadavg file",
+			loadavgContent: "",
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "no such file or directory",
+		},
+		{
+			name:           "whitespace only loadavg",
+			loadavgContent: whitespaceContent,
+			uptimeContent:  validUptimeContent,
+			wantErr:        true,
+			expectedErr:    "got 0 fields, expected 5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := createTestCollector(t, tt.loadavgContent, tt.uptimeContent)
+			result, err := collector.Collect(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			stats, ok := result.(*performance.LoadStats)
+			require.True(t, ok)
+			validateLoadStats(t, stats, tt.expected)
+		})
+	}
+}

--- a/pkg/performance/collectors/tcp.go
+++ b/pkg/performance/collectors/tcp.go
@@ -1,0 +1,364 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+)
+
+// TCPCollector collects TCP connection statistics from /proc/net/snmp, /proc/net/netstat, /proc/net/tcp*
+//
+// This collector reads TCP statistics from multiple proc files:
+// - /proc/net/snmp: Basic TCP statistics (RFC 1213 MIB-II)
+// - /proc/net/netstat: Extended TCP statistics (Linux-specific)
+// - /proc/net/tcp: IPv4 TCP connection states
+// - /proc/net/tcp6: IPv6 TCP connection states
+//
+// The statistics help monitor TCP performance, connection health, and
+// potential issues like SYN floods, connection drops, and retransmissions.
+//
+// References:
+// - https://www.kernel.org/doc/html/latest/networking/proc_net_tcp.html
+// - https://www.kernel.org/doc/html/latest/networking/snmp_counter.html
+type TCPCollector struct {
+	performance.BaseCollector
+	snmpPath    string
+	netstatPath string
+	tcpPath     string
+	tcp6Path    string
+}
+
+// TCP connection state mappings from kernel
+// These hexadecimal values correspond to the TCP state enum in the kernel
+// Reference: include/net/tcp_states.h
+var tcpStates = map[string]string{
+	"01": "ESTABLISHED", // Connection established
+	"02": "SYN_SENT",    // Sent SYN, waiting for SYN-ACK
+	"03": "SYN_RECV",    // Received SYN, sent SYN-ACK
+	"04": "FIN_WAIT1",   // Sent FIN, waiting for ACK or FIN
+	"05": "FIN_WAIT2",   // Received ACK of FIN, waiting for FIN
+	"06": "TIME_WAIT",   // Waiting for 2*MSL timeout
+	"07": "CLOSE",       // Connection closed
+	"08": "CLOSE_WAIT",  // Received FIN, waiting for app to close
+	"09": "LAST_ACK",    // Sent FIN after receiving FIN, waiting for ACK
+	"0A": "LISTEN",      // Listening for incoming connections
+	"0B": "CLOSING",     // Simultaneous close, waiting for ACK
+}
+
+func NewTCPCollector(logger logr.Logger, config performance.CollectionConfig) *TCPCollector {
+	capabilities := performance.CollectorCapabilities{
+		SupportsOneShot:    true,
+		SupportsContinuous: false,
+		RequiresRoot:       false,
+		RequiresEBPF:       false,
+		MinKernelVersion:   "2.6.0", // /proc/net/snmp has been around for a long time
+	}
+
+	return &TCPCollector{
+		BaseCollector: performance.NewBaseCollector(
+			performance.MetricTypeTCP,
+			"TCP Statistics Collector",
+			logger,
+			config,
+			capabilities,
+		),
+		snmpPath:    filepath.Join(config.HostProcPath, "net", "snmp"),
+		netstatPath: filepath.Join(config.HostProcPath, "net", "netstat"),
+		tcpPath:     filepath.Join(config.HostProcPath, "net", "tcp"),
+		tcp6Path:    filepath.Join(config.HostProcPath, "net", "tcp6"),
+	}
+}
+
+func (c *TCPCollector) Collect(ctx context.Context) (any, error) {
+	return c.collectTCPStats()
+}
+
+// collectTCPStats gathers TCP statistics from multiple proc files
+func (c *TCPCollector) collectTCPStats() (*performance.TCPStats, error) {
+	stats := &performance.TCPStats{
+		ConnectionsByState: make(map[string]uint64),
+	}
+
+	// Parse /proc/net/snmp for basic TCP statistics
+	if err := c.parseSNMP(stats); err != nil {
+		return nil, fmt.Errorf("failed to parse SNMP stats: %w", err)
+	}
+
+	// Parse /proc/net/netstat for extended TCP statistics
+	if err := c.parseNetstat(stats); err != nil {
+		// This is optional, so just log the error
+		c.Logger().V(1).Info("failed to parse netstat (continuing)", "error", err)
+	}
+
+	// Count TCP connections by state
+	if err := c.countConnectionStates(stats); err != nil {
+		// This is optional, so just log the error
+		c.Logger().V(1).Info("failed to count connection states (continuing)", "error", err)
+	}
+
+	return stats, nil
+}
+
+// parseSNMP parses /proc/net/snmp for TCP statistics
+//
+// /proc/net/snmp format:
+//
+//	Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+//	Tcp: 1 200 120000 -1 12345 67890 123 456 789 1234567 7654321 12345 0 123 0
+//
+// The file contains pairs of lines for each protocol:
+// - First line: Field names
+// - Second line: Corresponding values
+//
+// These are standard TCP MIB-II counters defined in RFC 1213.
+func (c *TCPCollector) parseSNMP(stats *performance.TCPStats) error {
+	file, err := os.Open(c.snmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", c.snmpPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var tcpHeader []string
+	var tcpValues []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 2 {
+			continue
+		}
+
+		// Look for TCP statistics
+		if fields[0] == "Tcp:" {
+			if tcpHeader == nil {
+				// This is the header line
+				tcpHeader = fields[1:]
+			} else {
+				// This is the values line
+				tcpValues = fields[1:]
+				break
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading %s: %w", c.snmpPath, err)
+	}
+
+	if len(tcpHeader) == 0 || len(tcpValues) == 0 {
+		return fmt.Errorf("TCP statistics not found in %s", c.snmpPath)
+	}
+
+	if len(tcpHeader) != len(tcpValues) {
+		return fmt.Errorf("TCP header/value length mismatch: %d != %d", len(tcpHeader), len(tcpValues))
+	}
+
+	// Map the values to our struct fields
+	for i, header := range tcpHeader {
+		value, err := strconv.ParseUint(tcpValues[i], 10, 64)
+		if err != nil {
+			continue // Skip fields we can't parse
+		}
+
+		switch header {
+		case "ActiveOpens":
+			stats.ActiveOpens = value
+		case "PassiveOpens":
+			stats.PassiveOpens = value
+		case "AttemptFails":
+			stats.AttemptFails = value
+		case "EstabResets":
+			stats.EstabResets = value
+		case "CurrEstab":
+			stats.CurrEstab = value
+		case "InSegs":
+			stats.InSegs = value
+		case "OutSegs":
+			stats.OutSegs = value
+		case "RetransSegs":
+			stats.RetransSegs = value
+		case "InErrs":
+			stats.InErrs = value
+		case "OutRsts":
+			stats.OutRsts = value
+		case "InCsumErrors":
+			stats.InCsumErrors = value
+		default:
+			// Log unknown fields at debug level
+			c.Logger().V(2).Info("Unknown TCP field in SNMP", "field", header, "value", value)
+		}
+	}
+
+	return nil
+}
+
+// parseNetstat parses /proc/net/netstat for extended TCP statistics
+//
+// /proc/net/netstat format is similar to /proc/net/snmp:
+//
+//	TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed ... TCPTimeouts ...
+//	TcpExt: 123 456 789 ... 12345 ...
+//
+// These are Linux-specific TCP extensions not covered by standard MIB-II.
+// They provide detailed insights into TCP behavior and performance issues.
+func (c *TCPCollector) parseNetstat(stats *performance.TCPStats) error {
+	file, err := os.Open(c.netstatPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", c.netstatPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var tcpExtHeader []string
+	var tcpExtValues []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 2 {
+			continue
+		}
+
+		// Look for TcpExt statistics
+		if fields[0] == "TcpExt:" {
+			if tcpExtHeader == nil {
+				// This is the header line
+				tcpExtHeader = fields[1:]
+			} else {
+				// This is the values line
+				tcpExtValues = fields[1:]
+				break
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading %s: %w", c.netstatPath, err)
+	}
+
+	if len(tcpExtHeader) == 0 || len(tcpExtValues) == 0 {
+		// TcpExt might not be present on all systems
+		return nil
+	}
+
+	if len(tcpExtHeader) != len(tcpExtValues) {
+		return fmt.Errorf("TcpExt header/value length mismatch: %d != %d", len(tcpExtHeader), len(tcpExtValues))
+	}
+
+	// Map the values to our struct fields
+	for i, header := range tcpExtHeader {
+		value, err := strconv.ParseUint(tcpExtValues[i], 10, 64)
+		if err != nil {
+			continue // Skip fields we can't parse
+		}
+
+		switch header {
+		case "SyncookiesSent":
+			stats.SyncookiesSent = value
+		case "SyncookiesRecv":
+			stats.SyncookiesRecv = value
+		case "SyncookiesFailed":
+			stats.SyncookiesFailed = value
+		case "ListenOverflows":
+			stats.ListenOverflows = value
+		case "ListenDrops":
+			stats.ListenDrops = value
+		case "TCPLostRetransmit":
+			stats.TCPLostRetransmit = value
+		case "TCPFastRetrans":
+			stats.TCPFastRetrans = value
+		case "TCPSlowStartRetrans":
+			stats.TCPSlowStartRetrans = value
+		case "TCPTimeouts":
+			stats.TCPTimeouts = value
+		}
+	}
+
+	return nil
+}
+
+// countConnectionStates counts TCP connections by state from /proc/net/tcp and /proc/net/tcp6
+func (c *TCPCollector) countConnectionStates(stats *performance.TCPStats) error {
+	// Initialize all known states to 0
+	for _, state := range tcpStates {
+		stats.ConnectionsByState[state] = 0
+	}
+
+	// Count IPv4 connections
+	if err := c.countConnectionsFromFile(c.tcpPath, stats); err != nil {
+		c.Logger().V(1).Info("failed to count IPv4 connections", "error", err)
+	}
+
+	// Count IPv6 connections
+	if err := c.countConnectionsFromFile(c.tcp6Path, stats); err != nil {
+		c.Logger().V(1).Info("failed to count IPv6 connections", "error", err)
+	}
+
+	return nil
+}
+
+// countConnectionsFromFile counts connections by state from a single tcp file
+//
+// /proc/net/tcp format (each line represents one connection):
+//
+//	sl  local_address rem_address   st tx_queue:rx_queue tr:tm->when retrnsmt   uid  timeout inode
+//	0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000   1000  0 12345 1 0000000000000000 100 0 0 10 0
+//
+// Fields we care about:
+// - sl: Entry number
+// - local_address: Local IP:Port in hex
+// - rem_address: Remote IP:Port in hex
+// - st: Connection state in hex (see tcpStates map)
+//
+// The same format applies to /proc/net/tcp6 for IPv6 connections.
+func (c *TCPCollector) countConnectionsFromFile(path string, stats *performance.TCPStats) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		if lineNum == 1 {
+			// Skip header line
+			continue
+		}
+
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		// Format: sl local_address rem_address st tx_queue:rx_queue ...
+		// We need at least 4 fields to get the state
+		if len(fields) < 4 {
+			continue
+		}
+
+		// State is in the 4th field (index 3)
+		stateHex := fields[3]
+		if stateName, ok := tcpStates[stateHex]; ok {
+			stats.ConnectionsByState[stateName]++
+		}
+	}
+
+	return scanner.Err()
+}

--- a/pkg/performance/collectors/tcp_test.go
+++ b/pkg/performance/collectors/tcp_test.go
@@ -1,0 +1,413 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/antimetal/agent/pkg/performance/collectors"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test data constants
+const (
+	validSNMPHeader = `Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
+Ip: 1 64 1000 0 0 0 0 0 1000 1000 0 0 0 0 0 0 0 0 0
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 100 200 10 5 8 50000 40000 500 2 15 3`
+
+	validNetstatHeader = `TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSPassive PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPFACKReorder TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPForwardRetrans TCPSlowStartRetrans TCPTimeouts
+TcpExt: 10 5 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 20 15 0 0 0 0 0 0 0 0 0 0 0 0 0 25 0 0 0 30 0 35 40`
+
+	validTCPHeader = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode`
+
+	validTCP6Header = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode`
+)
+
+func createTestCollector(t *testing.T, procPath string) *collectors.TCPCollector {
+	config := performance.CollectionConfig{
+		HostProcPath: procPath,
+		EnabledCollectors: map[performance.MetricType]bool{
+			performance.MetricTypeTCP: true,
+		},
+	}
+	return collectors.NewTCPCollector(logr.Discard(), config)
+}
+
+func setupTestFiles(t *testing.T, files map[string]string) string {
+	tempDir := t.TempDir()
+	netDir := filepath.Join(tempDir, "net")
+	require.NoError(t, os.MkdirAll(netDir, 0755))
+
+	for filename, content := range files {
+		path := filepath.Join(netDir, filename)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	return tempDir
+}
+
+func collectAndValidate(t *testing.T, collector *collectors.TCPCollector) *performance.TCPStats {
+	ctx := context.Background()
+	result, err := collector.Collect(ctx)
+	require.NoError(t, err)
+
+	stats, ok := result.(*performance.TCPStats)
+	require.True(t, ok, "expected *performance.TCPStats, got %T", result)
+	require.NotNil(t, stats.ConnectionsByState)
+
+	return stats
+}
+
+func TestTCPCollector_BasicFunctionality(t *testing.T) {
+	files := map[string]string{
+		"snmp":    validSNMPHeader,
+		"netstat": validNetstatHeader,
+		"tcp": validTCPHeader + `
+   0: 0100007F:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0277 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12346 1 0000000000000000 20 4 29 10 -1
+   2: 0100007F:0277 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12347 1 0000000000000000 20 4 29 10 -1
+   3: 0100007F:0277 0100007F:0050 06 00000000:00000000 00:00000000 00000000  1000        0 12348 1 0000000000000000 20 4 29 10 -1`,
+		"tcp6": validTCP6Header + `
+   0: 00000000000000000000000001000000:0050 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12349 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000001000000:0277 00000000000000000000000001000000:0050 01 00000000:00000000 00:00000000 00000000  1000        0 12350 1 0000000000000000 20 4 29 10 -1`,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	// Verify SNMP stats
+	assert.Equal(t, uint64(100), stats.ActiveOpens)
+	assert.Equal(t, uint64(200), stats.PassiveOpens)
+	assert.Equal(t, uint64(10), stats.AttemptFails)
+	assert.Equal(t, uint64(5), stats.EstabResets)
+	assert.Equal(t, uint64(8), stats.CurrEstab)
+	assert.Equal(t, uint64(50000), stats.InSegs)
+	assert.Equal(t, uint64(40000), stats.OutSegs)
+	assert.Equal(t, uint64(500), stats.RetransSegs)
+	assert.Equal(t, uint64(2), stats.InErrs)
+	assert.Equal(t, uint64(15), stats.OutRsts)
+	assert.Equal(t, uint64(3), stats.InCsumErrors)
+
+	// Verify netstat extended stats
+	assert.Equal(t, uint64(10), stats.SyncookiesSent)
+	assert.Equal(t, uint64(5), stats.SyncookiesRecv)
+	assert.Equal(t, uint64(2), stats.SyncookiesFailed)
+	assert.Equal(t, uint64(20), stats.ListenOverflows)
+	assert.Equal(t, uint64(15), stats.ListenDrops)
+	assert.Equal(t, uint64(25), stats.TCPLostRetransmit)
+	assert.Equal(t, uint64(30), stats.TCPFastRetrans)
+	assert.Equal(t, uint64(35), stats.TCPSlowStartRetrans)
+	assert.Equal(t, uint64(40), stats.TCPTimeouts)
+
+	// Verify connection states (IPv4 + IPv6)
+	assert.Equal(t, uint64(3), stats.ConnectionsByState["ESTABLISHED"]) // 2 IPv4 + 1 IPv6
+	assert.Equal(t, uint64(2), stats.ConnectionsByState["LISTEN"])      // 1 IPv4 + 1 IPv6
+	assert.Equal(t, uint64(1), stats.ConnectionsByState["TIME_WAIT"])   // 1 IPv4
+}
+
+func TestTCPCollector_MinorFormatVariations(t *testing.T) {
+	// Test realistic format variations that might occur
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "trailing_newline_variations",
+			files: map[string]string{
+				"snmp": validSNMPHeader + "\n", // Extra newline at end
+			},
+		},
+		{
+			name: "no_trailing_newline",
+			files: map[string]string{
+				"snmp": strings.TrimSuffix(validSNMPHeader, "\n"), // No trailing newline
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+
+			// Basic validation that parsing worked
+			assert.Equal(t, uint64(100), stats.ActiveOpens)
+			assert.Equal(t, uint64(8), stats.CurrEstab)
+		})
+	}
+}
+
+func TestTCPCollector_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "missing_snmp_file",
+			files:       map[string]string{},
+			expectError: true,
+			errorMsg:    "failed to parse SNMP stats",
+		},
+		{
+			name: "malformed_snmp_header_value_mismatch",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens
+Tcp: 1 200 120000 -1 100 200 10 5 8`,
+			},
+			expectError: true,
+			errorMsg:    "header/value length mismatch",
+		},
+		{
+			name: "empty_snmp_file",
+			files: map[string]string{
+				"snmp": "",
+			},
+			expectError: true,
+			errorMsg:    "TCP statistics not found",
+		},
+		{
+			name: "no_tcp_section_in_snmp",
+			files: map[string]string{
+				"snmp": `Ip: Forwarding DefaultTTL
+Ip: 1 64`,
+			},
+			expectError: true,
+			errorMsg:    "TCP statistics not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+
+			ctx := context.Background()
+			_, err := collector.Collect(ctx)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTCPCollector_GracefulDegradation(t *testing.T) {
+	tests := []struct {
+		name           string
+		files          map[string]string
+		validateResult func(*testing.T, *performance.TCPStats)
+	}{
+		{
+			name: "missing_netstat_file",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP stats should be present
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				// Netstat stats should be zero
+				assert.Equal(t, uint64(0), stats.SyncookiesSent)
+				assert.Equal(t, uint64(0), stats.ListenOverflows)
+			},
+		},
+		{
+			name: "missing_tcp_files",
+			files: map[string]string{
+				"snmp":    validSNMPHeader,
+				"netstat": validNetstatHeader,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP and netstat stats should be present
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				assert.Equal(t, uint64(10), stats.SyncookiesSent)
+				// Connection states should be initialized but empty
+				assert.NotNil(t, stats.ConnectionsByState)
+				for _, state := range []string{"ESTABLISHED", "LISTEN", "TIME_WAIT"} {
+					assert.Equal(t, uint64(0), stats.ConnectionsByState[state])
+				}
+			},
+		},
+		{
+			name: "malformed_netstat_continues",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"netstat": `TcpExt: Field1 Field2
+TcpExt: NotANumber 456`,
+			},
+			validateResult: func(t *testing.T, stats *performance.TCPStats) {
+				// SNMP stats should still work
+				assert.Equal(t, uint64(100), stats.ActiveOpens)
+				// Netstat parsing should have failed gracefully
+				assert.Equal(t, uint64(0), stats.SyncookiesSent)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+			tt.validateResult(t, stats)
+		})
+	}
+}
+
+func TestTCPCollector_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		check func(*testing.T, *performance.TCPStats)
+	}{
+		{
+			name: "extreme_values",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 18446744073709551615 18446744073709551615 0 0 0 0 0 0 0 0 0`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				assert.Equal(t, uint64(18446744073709551615), stats.ActiveOpens) // Max uint64
+				assert.Equal(t, uint64(18446744073709551615), stats.PassiveOpens)
+			},
+		},
+		{
+			name: "non_numeric_values_skipped",
+			files: map[string]string{
+				"snmp": `Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 ABC 200 10 5 8 50000 40000 500 2 15 3`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				assert.Equal(t, uint64(0), stats.ActiveOpens) // Should be 0 due to parse error
+				assert.Equal(t, uint64(200), stats.PassiveOpens)
+			},
+		},
+		{
+			name: "unknown_tcp_states",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"tcp": validTCPHeader + `
+   0: 0100007F:0050 00000000:0000 FF 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0277 0100007F:0050 ZZ 00000000:00000000 00:00000000 00000000  1000        0 12346 1 0000000000000000 20 4 29 10 -1`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				// Unknown states should be ignored
+				assert.Equal(t, uint64(0), stats.ConnectionsByState["ESTABLISHED"])
+			},
+		},
+		{
+			name: "short_tcp_lines",
+			files: map[string]string{
+				"snmp": validSNMPHeader,
+				"tcp": validTCPHeader + `
+   0: 0100007F:0050
+   1: incomplete line`,
+			},
+			check: func(t *testing.T, stats *performance.TCPStats) {
+				// Short lines should be skipped
+				for _, count := range stats.ConnectionsByState {
+					assert.Equal(t, uint64(0), count)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procPath := setupTestFiles(t, tt.files)
+			collector := createTestCollector(t, procPath)
+			stats := collectAndValidate(t, collector)
+			tt.check(t, stats)
+		})
+	}
+}
+
+func TestTCPCollector_AllConnectionStates(t *testing.T) {
+	// Test all possible TCP states
+	stateMap := map[string]string{
+		"01": "ESTABLISHED",
+		"02": "SYN_SENT",
+		"03": "SYN_RECV",
+		"04": "FIN_WAIT1",
+		"05": "FIN_WAIT2",
+		"06": "TIME_WAIT",
+		"07": "CLOSE",
+		"08": "CLOSE_WAIT",
+		"09": "LAST_ACK",
+		"0A": "LISTEN",
+		"0B": "CLOSING",
+	}
+
+	var tcpContent strings.Builder
+	tcpContent.WriteString(validTCPHeader + "\n")
+
+	// Create one connection for each state
+	i := 0
+	for hexState, _ := range stateMap {
+		line := fmt.Sprintf("  %2d: 0100007F:%04X 0100007F:0050 %s 00000000:00000000 00:00000000 00000000  1000        0 %d 1 0000000000000000 20 4 29 10 -1\n",
+			i, 0x1000+i, hexState, 12345+i)
+		tcpContent.WriteString(line)
+		i++
+	}
+
+	files := map[string]string{
+		"snmp": validSNMPHeader,
+		"tcp":  tcpContent.String(),
+		"tcp6": validTCP6Header,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	// Verify each state has exactly one connection
+	for hexState, stateName := range stateMap {
+		assert.Equal(t, uint64(1), stats.ConnectionsByState[stateName],
+			"State %s (%s) should have 1 connection", stateName, hexState)
+	}
+}
+
+func TestTCPCollector_LargeFiles(t *testing.T) {
+	// Test with many connections
+	var tcpContent strings.Builder
+	tcpContent.WriteString(validTCPHeader + "\n")
+
+	// Create 1000 connections
+	expectedEstablished := 1000
+	for i := 0; i < expectedEstablished; i++ {
+		line := fmt.Sprintf("  %2d: 0100007F:%04X 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 %d 1 0000000000000000 20 4 29 10 -1\n",
+			i, 0x1000+i, 12345+i)
+		tcpContent.WriteString(line)
+	}
+
+	files := map[string]string{
+		"snmp": validSNMPHeader,
+		"tcp":  tcpContent.String(),
+		"tcp6": validTCP6Header,
+	}
+
+	procPath := setupTestFiles(t, files)
+	collector := createTestCollector(t, procPath)
+	stats := collectAndValidate(t, collector)
+
+	assert.Equal(t, uint64(expectedEstablished), stats.ConnectionsByState["ESTABLISHED"])
+}

--- a/pkg/performance/types.go
+++ b/pkg/performance/types.go
@@ -248,31 +248,31 @@ type NetworkStats struct {
 // TCPStats represents TCP connection statistics
 type TCPStats struct {
 	// Connection counts from /proc/net/snmp (Tcp: line)
-	ActiveOpens  uint64 // Active connection openings
-	PassiveOpens uint64 // Passive connection openings
-	AttemptFails uint64 // Failed connection attempts
-	EstabResets  uint64 // Resets from established state
-	CurrEstab    uint64 // Current established connections
-	InSegs       uint64 // Segments received
-	OutSegs      uint64 // Segments sent
-	RetransSegs  uint64 // Segments retransmitted
-	InErrs       uint64 // Segments received with errors
-	OutRsts      uint64 // RST segments sent
-	InCsumErrors uint64 // Segments with checksum errors
+	ActiveOpens  uint64 // Active connection openings (count since boot)
+	PassiveOpens uint64 // Passive connection openings (count since boot)
+	AttemptFails uint64 // Failed connection attempts (count since boot)
+	EstabResets  uint64 // Resets from established state (count since boot)
+	CurrEstab    uint64 // Current established connections (instantaneous count)
+	InSegs       uint64 // Segments received (count since boot)
+	OutSegs      uint64 // Segments sent (count since boot)
+	RetransSegs  uint64 // Segments retransmitted (count since boot)
+	InErrs       uint64 // Segments received with errors (count since boot)
+	OutRsts      uint64 // RST segments sent (count since boot)
+	InCsumErrors uint64 // Segments with checksum errors (count since boot)
 	// Extended TCP stats from /proc/net/netstat (TcpExt: line)
-	SyncookiesSent      uint64 // SYN cookies sent
-	SyncookiesRecv      uint64 // SYN cookies received
-	SyncookiesFailed    uint64 // SYN cookies failed
-	ListenOverflows     uint64 // Listen queue overflows
-	ListenDrops         uint64 // Listen queue drops
-	TCPLostRetransmit   uint64 // Lost retransmissions
-	TCPFastRetrans      uint64 // Fast retransmissions
-	TCPSlowStartRetrans uint64 // Slow start retransmissions
-	TCPTimeouts         uint64 // TCP timeouts
+	SyncookiesSent      uint64 // SYN cookies sent (count since boot)
+	SyncookiesRecv      uint64 // SYN cookies received (count since boot)
+	SyncookiesFailed    uint64 // SYN cookies failed (count since boot)
+	ListenOverflows     uint64 // Listen queue overflows (count since boot)
+	ListenDrops         uint64 // Listen queue drops (count since boot)
+	TCPLostRetransmit   uint64 // Lost retransmissions (count since boot)
+	TCPFastRetrans      uint64 // Fast retransmissions (count since boot)
+	TCPSlowStartRetrans uint64 // Slow start retransmissions (count since boot)
+	TCPTimeouts         uint64 // TCP timeouts (count since boot)
 	// Connection states from /proc/net/tcp and /proc/net/tcp6
 	// States: ESTABLISHED, SYN_SENT, SYN_RECV, FIN_WAIT1, FIN_WAIT2,
 	// TIME_WAIT, CLOSE, CLOSE_WAIT, LAST_ACK, LISTEN, CLOSING
-	ConnectionsByState map[string]uint64
+	ConnectionsByState map[string]uint64 // Current count per state (instantaneous)
 }
 
 // KernelMessage represents a kernel log message from /dev/kmsg


### PR DESCRIPTION
## Summary
- Converted DiskCollector from continuous to point collector architecture
- Removed rate/delta calculations to be handled at a higher level
- Updated tests to follow project testing methodology

## Changes
- Converted from `BaseContinuousCollector` to `BaseCollector`
- Removed all continuous collection logic (Start, Stop, goroutines, channels)
- Removed windowed averaging and rate calculations
- Removed context cancellation as point collectors are synchronous
- Exports `IsPartition` function for testing
- Completely rewrote tests following TCP collector patterns

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Test coverage maintained
- [ ] Integration testing with agent

🤖 Generated with [Claude Code](https://claude.ai/code)