### PR TITLE
feat: Set up GitHub-Linear integration workflow - Fixes ENG-1398

### DIFF
--- a/.github/workflows/linear-sync.yml
+++ b/.github/workflows/linear-sync.yml
@@ -17,7 +17,7 @@ jobs:
           -H "Authorization: ${{ secrets.LINEAR_API_TOKEN }}" \
           -H "Content-Type: application/json" \
           -d '{
-            "query": "mutation { issueCreate(input: { title: \"${{ github.event.issue.title }}\", description: \"GitHub Issue: ${{ github.event.issue.html_url }}\\n\\n${{ github.event.issue.body }}\", teamId: \"19663b87-b6c8-4844-a03d-f63266192ca1\" }) { issue { identifier url } } }"
+            "query": "mutation { issueCreate(input: { title: \"${{ github.event.issue.title }}\", description: \"GitHub Issue: ${{ github.event.issue.html_url }}\\n\\n${{ github.event.issue.body }}\", teamId: \"${{ vars.LINEAR_TEAM_ID }}\" }) { issue { identifier url } } }"
           }' \
           https://api.linear.app/graphql
           

--- a/docs/LINEAR_GITHUB_INTEGRATION.md
+++ b/docs/LINEAR_GITHUB_INTEGRATION.md
@@ -24,3 +24,6 @@ planning. The integration automatically syncs minimal information of public chan
 
 ### GitHub Secrets
 - `LINEAR_API_TOKEN`: Linear API token for creating issues
+
+### GitHub Variables
+- `LINEAR_TEAM_ID`: Linear team ID where GitHub issues will be created


### PR DESCRIPTION
## Summary

This PR sets up a GitHub-Linear integration workflow to automatically sync GitHub issues with Linear. The integration creates a one-way sync from GitHub to Linear for better internal tracking.

### Changes Made

- **GitHub Workflow** (`.github/workflows/linear-sync.yml`):
  - Triggers on GitHub issue events (opened, closed, reopened)
  - Automatically creates Linear issues when GitHub issues are opened
  - Updates Linear issue status when GitHub issues are closed/reopened

- **Documentation** (`docs/LINEAR_GITHUB_INTEGRATION.md`):
  - Explains the integration workflow
  - Details automatic GitHub → Linear issue creation
  - Describes PR linking strategy via GitHub issues
  - Documents required GitHub secrets (`LINEAR_API_TOKEN`)

### Integration Flow

1. **GitHub Issue Created** → Automatically creates corresponding Linear issue
2. **GitHub Issue Closed/Reopened** → Updates Linear issue status
3. **Pull Requests** → User can ink to GitHub issues (which are already synced to Linear)

This enables public GitHub issue tracking while maintaining internal Linear workflow visibility.

**Fixes**: ENG-1398