### PR TITLE
Add wrappers that transforms PointCollectors in to ContinuousCollectors

### DIFF
--- a/pkg/performance/collector_test.go
+++ b/pkg/performance/collector_test.go
@@ -1,0 +1,244 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package performance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+)
+
+// TestCollector implements the PointCollector interface for testing
+type TestCollector struct {
+	performance.BaseCollector
+}
+
+func NewTestCollector() *TestCollector {
+	capabilities := performance.CollectorCapabilities{
+		SupportsOneShot:    true,
+		SupportsContinuous: false,
+		RequiresRoot:       false,
+		RequiresEBPF:       false,
+	}
+
+	return &TestCollector{
+		BaseCollector: performance.NewBaseCollector(
+			performance.MetricType("test"),
+			"test-collector",
+			logr.Discard(),
+			performance.CollectionConfig{},
+			capabilities,
+		),
+	}
+}
+
+func (tc *TestCollector) Collect(ctx context.Context) (any, error) {
+	testData := map[string]any{
+		"timestamp": time.Now().Format(time.RFC3339),
+		"metric":    "test_value",
+		"value":     42,
+		"status":    "success",
+	}
+	return testData, nil
+}
+
+func TestContinuousPointCollector(t *testing.T) {
+	testCollector := NewTestCollector()
+	config := performance.CollectionConfig{
+		Interval: 100 * time.Millisecond,
+	}
+	continuousCollector := performance.NewContinuousPointCollector(testCollector, config, logr.Discard())
+
+	// Test basic properties
+	if continuousCollector.Type() != performance.MetricType("test") {
+		t.Errorf("Expected type 'test', got %s", continuousCollector.Type())
+	}
+
+	if continuousCollector.Name() != "test-collector" {
+		t.Errorf("Expected name 'test-collector', got %s", continuousCollector.Name())
+	}
+
+	caps := continuousCollector.Capabilities()
+	if caps.SupportsOneShot {
+		t.Error("Expected SupportsOneShot to be false")
+	}
+	if !caps.SupportsContinuous {
+		t.Error("Expected SupportsContinuous to be true")
+	}
+
+	// Test initial status
+	if continuousCollector.Status() != performance.CollectorStatusDisabled {
+		t.Errorf("Expected status disabled, got %s", continuousCollector.Status())
+	}
+
+	// Start the collector
+	ch, err := continuousCollector.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to start collector: %v", err)
+	}
+
+	// Verify status changed to active
+	if continuousCollector.Status() != performance.CollectorStatusActive {
+		t.Errorf("Expected status active after start, got %s", continuousCollector.Status())
+	}
+
+	// Collect a few data points
+	var dataPoints []any
+	timeout := time.After(1 * time.Second)
+
+	for len(dataPoints) < 3 {
+		select {
+		case data := <-ch:
+			dataPoints = append(dataPoints, data)
+			t.Logf("Received data point %d: %+v", len(dataPoints), data)
+		case <-timeout:
+			t.Fatalf("Timeout waiting for data points. Got %d points", len(dataPoints))
+		}
+	}
+
+	// Stop the collector
+	err = continuousCollector.Stop()
+	if err != nil {
+		t.Errorf("Failed to stop collector: %v", err)
+	}
+
+	if continuousCollector.Status() != performance.CollectorStatusDisabled {
+		t.Errorf("Expected status disabled after stop, got %s", continuousCollector.Status())
+	}
+	if len(dataPoints) < 3 {
+		t.Errorf("Expected at least 3 data points, got %d", len(dataPoints))
+	}
+}
+
+func TestContinuousPointCollector_ContextCancellation(t *testing.T) {
+	testCollector := NewTestCollector()
+	config := performance.CollectionConfig{
+		Interval: 50 * time.Millisecond,
+	}
+	continuousCollector := performance.NewContinuousPointCollector(testCollector, config, logr.Discard())
+
+	// Start the collector
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := continuousCollector.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start collector: %v", err)
+	}
+
+	// Collect one data point to ensure it's working
+	select {
+	case data := <-ch:
+		t.Logf("Received initial data point: %+v", data)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Timeout waiting for initial data point")
+	}
+
+	// Cancel the context and stop the collector and allow some time for the collector to stop
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+	// Verify status changed to disabled
+	if continuousCollector.Status() != performance.CollectorStatusDisabled {
+		t.Errorf("Expected status disabled after stop, got %s", continuousCollector.Status())
+	}
+}
+
+func TestOnceContinuousCollector(t *testing.T) {
+	testCollector := NewTestCollector()
+	config := performance.CollectionConfig{}
+	onceCollector := performance.NewOnceContinuousCollector(
+		testCollector, config, logr.Discard(),
+	)
+
+	// Test basic properties
+	if onceCollector.Type() != performance.MetricType("test") {
+		t.Errorf("Expected type 'test', got %s", onceCollector.Type())
+	}
+
+	if onceCollector.Name() != "test-collector" {
+		t.Errorf("Expected name 'test-collector', got %s", onceCollector.Name())
+	}
+
+	caps := onceCollector.Capabilities()
+	if !caps.SupportsOneShot {
+		t.Error("Expected SupportsOneShot to be true")
+	}
+	if caps.SupportsContinuous {
+		t.Error("Expected SupportsContinuous to be false")
+	}
+
+	// Test initial status
+	if onceCollector.Status() != performance.CollectorStatusDisabled {
+		t.Errorf("Expected status disabled, got %s", onceCollector.Status())
+	}
+
+	// Start the collector
+	ctx := context.Background()
+	ch, err := onceCollector.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start collector: %v", err)
+	}
+
+	// Verify status changed to active
+	if onceCollector.Status() != performance.CollectorStatusActive {
+		t.Errorf("Expected status active after start, got %s", onceCollector.Status())
+	}
+
+	testCollect := func(ch <-chan any) {
+		// Collect the single data point
+		var data any
+		var chOpen bool
+
+		select {
+		case data, chOpen = <-ch:
+			break
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("Timeout waiting for data point")
+		}
+
+		// Verify we received data
+		if data == nil {
+			t.Error("Expected to receive data, got nil")
+		}
+
+		// Verify channel is closed after one-shot collection
+		select {
+		case data, chOpen = <-ch:
+			break
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("Timeout waiting for data point")
+		}
+
+		if chOpen {
+			t.Error("Expected channel to be closed after one-shot collection, but it is still open")
+		}
+	}
+
+	testCollect(ch)
+
+	// Stop the collector
+	err = onceCollector.Stop()
+	if err != nil {
+		t.Errorf("Failed to stop collector: %v", err)
+	}
+
+	// Verify status changed to disabled
+	if onceCollector.Status() != performance.CollectorStatusDisabled {
+		t.Errorf("Expected status disabled after stop, got %s", onceCollector.Status())
+	}
+
+	// Start the channel again and verify we get the same data
+	ch, err = onceCollector.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start collector again: %v", err)
+	}
+	if onceCollector.Status() != performance.CollectorStatusActive {
+		t.Errorf("Expected status active after start, got %s", onceCollector.Status())
+	}
+	testCollect(ch)
+}

--- a/pkg/performance/collectors/load_test.go
+++ b/pkg/performance/collectors/load_test.go
@@ -1,3 +1,9 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package collectors_test
 
 import (

--- a/pkg/performance/registry.go
+++ b/pkg/performance/registry.go
@@ -1,0 +1,107 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package performance
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+type CollectorRegistry struct {
+	pointCollectors      map[MetricType]PointCollector
+	continuousCollectors map[MetricType]ContinuousCollector
+	logger               logr.Logger
+}
+
+func NewCollectorRegistry(logger logr.Logger) *CollectorRegistry {
+	return &CollectorRegistry{
+		pointCollectors:      make(map[MetricType]PointCollector),
+		continuousCollectors: make(map[MetricType]ContinuousCollector),
+		logger:               logger.WithName("registry"),
+	}
+}
+
+func (r *CollectorRegistry) RegisterPoint(collector PointCollector) error {
+	if collector == nil {
+		return fmt.Errorf("cannot register nil collector")
+	}
+
+	metricType := collector.Type()
+	if _, exists := r.pointCollectors[metricType]; exists {
+		return fmt.Errorf("point collector for metric type %s already registered", metricType)
+	}
+	if _, exists := r.continuousCollectors[metricType]; exists {
+		return fmt.Errorf("continuous collector for metric type %s already registered", metricType)
+	}
+
+	r.pointCollectors[metricType] = collector
+	r.logger.Info("registered point collector", "type", metricType, "name", collector.Name())
+	return nil
+}
+
+func (r *CollectorRegistry) RegisterContinuous(collector ContinuousCollector) error {
+	if collector == nil {
+		return fmt.Errorf("cannot register nil collector")
+	}
+
+	metricType := collector.Type()
+	if _, exists := r.continuousCollectors[metricType]; exists {
+		return fmt.Errorf("continuous collector for metric type %s already registered", metricType)
+	}
+	if _, exists := r.pointCollectors[metricType]; exists {
+		return fmt.Errorf("point collector for metric type %s already registered", metricType)
+	}
+
+	r.continuousCollectors[metricType] = collector
+	r.logger.Info("registered continuous collector", "type", metricType, "name", collector.Name())
+	return nil
+}
+
+func (r *CollectorRegistry) GetPoint(metricType MetricType) PointCollector {
+	return r.pointCollectors[metricType]
+}
+
+func (r *CollectorRegistry) GetContinuous(metricType MetricType) ContinuousCollector {
+	return r.continuousCollectors[metricType]
+}
+
+func (r *CollectorRegistry) GetAllPoint() []PointCollector {
+	collectors := make([]PointCollector, 0, len(r.pointCollectors))
+	for _, collector := range r.pointCollectors {
+		collectors = append(collectors, collector)
+	}
+	return collectors
+}
+
+func (r *CollectorRegistry) GetAllContinuous() []ContinuousCollector {
+	collectors := make([]ContinuousCollector, 0, len(r.continuousCollectors))
+	for _, collector := range r.continuousCollectors {
+		collectors = append(collectors, collector)
+	}
+	return collectors
+}
+
+func (r *CollectorRegistry) GetEnabledPoint(config CollectionConfig) []PointCollector {
+	var enabled []PointCollector
+	for metricType, collector := range r.pointCollectors {
+		if config.EnabledCollectors[metricType] {
+			enabled = append(enabled, collector)
+		}
+	}
+	return enabled
+}
+
+func (r *CollectorRegistry) GetEnabledContinuous(config CollectionConfig) []ContinuousCollector {
+	var enabled []ContinuousCollector
+	for metricType, collector := range r.continuousCollectors {
+		if config.EnabledCollectors[metricType] {
+			enabled = append(enabled, collector)
+		}
+	}
+	return enabled
+}

--- a/tools/license_check/license_check.py
+++ b/tools/license_check/license_check.py
@@ -28,6 +28,7 @@ header = """// Copyright Antimetal, Inc. All rights reserved.
 exclude_dirs = (
   './.git',
   './vendor',
+  './pkg/api',
 )
 
 def check_file(file_path: str) -> None:


### PR DESCRIPTION
## Summary
- ContinuousPointCollector wraps a PointCollector into a ContinuousCollector that calls Collect() on an interval

- OnceContinuousCollector is a ContinuousCollector that wraps a PointCollector and performs a one-shot collection.

  Start() will call Collect() once and return the result in a channel with a buffer size of 1 and then close it. This is useful for   collectors that only need to run once because the information collected doesn't change (e.g. hardware info).

## Test plan
- [x] Run existing collector tests to ensure no regressions
- [x] New tests cover edge cases and error conditions
- [x] Verify channel lifecycle management works correctly