### PR TITLE
feat: centralize path validation in CollectionConfig

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,5 @@
 name: Claude Code Review
+description: Provides AI-powered code review using Claude on pull requests
 
 on:
   pull_request:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,5 @@
 name: Claude Code
+description: Responds to mentions of Claude in issue and PR comments to provide assistance
 
 on:
   issue_comment:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,13 @@ jobs:
           additional_permissions: |
             actions: read
           
+          # Custom instructions to handle review requests in comments
+          custom_instructions: |
+            If someone asks you to review a PR with commands like "@claude review", "@claude please review", or "@claude code review":
+            1. Provide a comprehensive code review following the guidelines in CLAUDE.md
+            2. Focus on the same aspects as automated reviews: code quality, bugs, performance, security, and test coverage
+            3. Use collapsible sections for non-actionable feedback as specified in CLAUDE.md
+          
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
           

--- a/.github/workflows/hardware-collector-tests.yml
+++ b/.github/workflows/hardware-collector-tests.yml
@@ -2,6 +2,8 @@ name: Hardware Collector Real Hardware Tests
 
 on:
   push:
+    branches:
+      - main
     paths: 
       - 'pkg/performance/collectors/**'
       - 'pkg/performance/types.go'

--- a/.github/workflows/linear-sync.yml
+++ b/.github/workflows/linear-sync.yml
@@ -1,4 +1,5 @@
 name: Linear Sync
+description: Synchronizes GitHub issues with Linear tasks - creates Linear issues when GitHub issues are opened
 
 on:
   issues:
@@ -12,6 +13,19 @@ jobs:
     steps:
     - name: Create Linear Issue
       run: |
+        # Validate required variables
+        if [ -z "${{ vars.LINEAR_TEAM_ID }}" ]; then
+          echo "ERROR: LINEAR_TEAM_ID variable is not set"
+          echo "Please configure LINEAR_TEAM_ID in your repository variables"
+          exit 1
+        fi
+        
+        if [ -z "${{ secrets.LINEAR_API_TOKEN }}" ]; then
+          echo "ERROR: LINEAR_API_TOKEN secret is not set"
+          echo "Please configure LINEAR_API_TOKEN in your repository secrets"
+          exit 1
+        fi
+        
         # Build description
         DESCRIPTION="GitHub Issue: ${{ github.event.issue.html_url }}
         

--- a/.vars.example
+++ b/.vars.example
@@ -3,4 +3,4 @@
 # NEVER commit the .vars file to version control
 
 # Linear Team ID for Engineering
-LINEAR_TEAM_ID=19663b87-b6c8-4844-a03d-f63266192ca1
+LINEAR_TEAM_ID=REPLACE_WITH_YOUR_TEAM_ID

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,42 @@ type ContinuousCollector interface {
 
 ### Collector Implementation Patterns
 
+#### Constructor Pattern
+All collectors must follow a consistent constructor pattern:
+```go
+func NewXCollector(logger logr.Logger, config performance.CollectionConfig) (*XCollector, error) {
+    // 1. Validate paths are absolute
+    if !filepath.IsAbs(config.HostProcPath) {
+        return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+    }
+    if !filepath.IsAbs(config.HostSysPath) {  // If collector uses sysfs
+        return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+    }
+    
+    // 2. Define capabilities
+    capabilities := performance.CollectorCapabilities{
+        SupportsOneShot:    true,
+        SupportsContinuous: false,
+        RequiresRoot:       false,
+        RequiresEBPF:       false,
+        MinKernelVersion:   "2.6.0",
+    }
+    
+    // 3. Return collector with pre-computed paths
+    return &XCollector{
+        BaseCollector: performance.NewBaseCollector(...),
+        specificPath: filepath.Join(config.HostProcPath, "specific/file"),
+    }, nil
+}
+```
+
+#### Compile-Time Interface Checks
+Every collector must include a compile-time interface check:
+```go
+// Compile-time interface check
+var _ performance.Collector = (*NetworkCollector)(nil)
+```
+
 #### Base Collector Pattern
 ```go
 type BaseCollector struct {
@@ -225,6 +261,22 @@ type CollectorCapabilities struct {
 }
 ```
 
+#### Error Handling Strategy
+Collectors must clearly distinguish between critical and optional data:
+- **Critical files**: Return error immediately if unavailable (e.g., /proc/loadavg for LoadCollector)
+- **Optional files**: Log warning and continue with graceful degradation (e.g., /sys/class/net/* metadata)
+- **Parse errors**: Handle based on field importance - critical fields cause errors, optional fields are logged
+
+Document the error handling strategy in method comments:
+```go
+// collectNetworkStats reads network statistics
+//
+// Error handling strategy:
+// - /proc/net/dev is critical - returns error if unavailable
+// - /sys/class/net/* files are optional - logs warnings but continues
+// - Malformed lines in /proc/net/dev are skipped with logging
+```
+
 ### Performance Collector Testing Methodology
 
 #### Standardized Testing Approach
@@ -245,30 +297,126 @@ Performance collectors follow a comprehensive testing pattern:
 
 3. **Key Testing Patterns**
    ```go
-   // Helper function pattern
-   func createTestCollector(t *testing.T, content string) *Collector {
+   // Helper function pattern - consistent naming and structure
+   func createTestXCollector(t *testing.T, procContent string, sysFiles map[string]string) (*XCollector, string, string) {
        tmpDir := t.TempDir()
-       // Create mock files
-       return collector
+       procPath := filepath.Join(tmpDir, "proc")
+       sysPath := filepath.Join(tmpDir, "sys")
+       
+       // Setup mock files...
+       
+       config := performance.CollectionConfig{
+           HostProcPath: procPath,
+           HostSysPath:  sysPath,
+       }
+       collector, err := collectors.NewXCollector(logr.Discard(), config)
+       require.NoError(t, err)
+       
+       return collector, procPath, sysPath
    }
    
-   // Validation helper pattern
-   func validateResults(t *testing.T, actual, expected *Stats) {
-       assert.Equal(t, expected.Field, actual.Field)
+   // Collection and validation helper
+   func collectAndValidateX(t *testing.T, collector *XCollector, expectError bool, validate func(t *testing.T, result TypedResult)) {
+       result, err := collector.Collect(context.Background())
+       
+       if expectError {
+           assert.Error(t, err)
+           return
+       }
+       
+       require.NoError(t, err)
+       typedResult, ok := result.(TypedResult)
+       require.True(t, ok, "result should be TypedResult")
+       
+       if validate != nil {
+           validate(t, typedResult)
+       }
    }
+   
+   // Test data as constants
+   const validProcFile = `actual /proc file content here`
+   const malformedProcFile = `malformed content`
    ```
 
 4. **Testing Requirements**
-   - **Path validation**: Test absolute vs relative paths
+   - **Constructor tests**: Separate test function for constructor validation
+   - **Path validation**: Test absolute vs relative paths, empty paths
    - **File interdependency**: Test behavior when related files unavailable
-   - **Return type validation**: Explicit type assertions
-   - **Graceful degradation**: Document critical vs optional files
+   - **Return type validation**: Explicit type assertions with proper error messages
+   - **Graceful degradation**: Document and test critical vs optional files
+   - **Boundary conditions**: Test zero values, maximum values (e.g., max uint64)
+   - **Malformed input**: Test partial data, missing fields, corrupt formats
+   - **Special cases**: Test virtual interfaces, disabled devices, etc.
 
 5. **Testing Principles**
    - Don't test static properties (Name, RequiresRoot)
    - Focus on parsing logic and error handling
    - Use realistic test data from actual /proc files
-   - Test collectors in `collectors_test` package
+   - Test collectors in `collectors_test` package (external testing)
+   - Name test functions consistently: `TestXCollector_Constructor`, `TestXCollector_Collect`
+   - Use descriptive test names that explain the scenario
+   - Group related test scenarios in the same test function
+
+6. **Documentation Standards**
+   - **Type-level documentation**: Explain purpose, data sources, references
+   - **Method documentation**: Include format examples and error handling strategy
+   - **Inline documentation**: Explain complex parsing logic or non-obvious decisions
+   - **Reference links**: Include kernel documentation links where applicable
+
+### Collector Development Workflow
+
+When adding a new performance collector:
+
+1. **Define the data structure** in `pkg/performance/types.go`
+2. **Create the collector** in `pkg/performance/collectors/your_collector.go`
+   - Include compile-time interface check
+   - Follow constructor pattern with path validation
+   - Document error handling strategy
+3. **Create comprehensive tests** in `pkg/performance/collectors/your_collector_test.go`
+   - Use `collectors_test` package
+   - Include constructor tests
+   - Add helper functions following naming patterns
+   - Test edge cases and error scenarios
+4. **Update collector registry** if applicable
+5. **Run validation**:
+   ```bash
+   make test                    # Run tests
+   make lint                    # Check code style
+   make gen-license-headers     # Ensure license headers
+   ```
+
+### Common Collector Patterns
+
+#### Reading Single Value Files
+```go
+data, err := os.ReadFile(c.somePath)
+if err != nil {
+    return nil, fmt.Errorf("failed to read %s: %w", c.somePath, err)
+}
+value := strings.TrimSpace(string(data))
+```
+
+#### Parsing Multi-Line Files
+```go
+scanner := bufio.NewScanner(file)
+for scanner.Scan() {
+    line := scanner.Text()
+    // Parse line
+}
+if err := scanner.Err(); err != nil {
+    return nil, fmt.Errorf("error reading %s: %w", c.somePath, err)
+}
+```
+
+#### Handling Optional Metadata
+```go
+// Try to read optional file, but don't fail if missing
+if data, err := os.ReadFile(optionalPath); err == nil {
+    // Process optional data
+} else {
+    c.Logger().V(2).Info("Optional file not available", "path", optionalPath, "error", err)
+}
+```
 
 ## Resource Store Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,55 @@
 
 This file provides comprehensive guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Code Review Guidelines
+
+When performing code reviews on pull requests:
+
+### Feedback Structure
+- **IMPORTANT**: Use collapsible sections (`<details>` tags) for non-actionable feedback, explanations, or background information
+- Keep actionable items (bugs, required changes) visible by default
+- Use this format for non-critical suggestions:
+
+```markdown
+<details>
+<summary>💡 Suggestion: [Brief description]</summary>
+
+[Detailed explanation or rationale]
+
+</details>
+```
+
+### Example Review Format
+```markdown
+## Review Summary
+✅ **Required Changes** (visible by default)
+- Fix memory leak in line 42
+- Add error handling for null case
+
+<details>
+<summary>📚 Code Quality Observations</summary>
+
+- Consider using early returns to reduce nesting
+- The function could be split into smaller units
+- Variable naming could be more descriptive
+
+</details>
+
+<details>
+<summary>🔍 Performance Considerations</summary>
+
+While not critical, you might consider:
+- Using a map instead of repeated array lookups
+- Caching the compiled regex pattern
+
+</details>
+```
+
+### Review Priorities
+1. **Always visible**: Security issues, bugs, breaking changes
+2. **Collapsible**: Style suggestions, minor optimizations, educational content
+3. **Focus on**: Constructive, actionable feedback over nitpicking
+
 ## Project Overview
 
 The Antimetal Agent is a sophisticated Kubernetes controller written in Go that connects infrastructure to the Antimetal platform for cloud resource management. It's designed as a cloud-native agent that:

--- a/Makefile
+++ b/Makefile
@@ -270,13 +270,13 @@ build-and-load-image: docker-build load-image ## Builds and loads Docker image i
 
 .PHONY: test-actions
 test-actions: ## Test GitHub Actions locally with act (requires act to be installed)
-	@command -v act >/dev/null 2>&1 || { echo "act is not installed. Run: brew install act"; exit 1; }
+	@command -v act >/dev/null 2>&1 || { echo "act is not installed. See installation instructions at: https://github.com/nektos/act#installation"; exit 1; }
 	@echo "Available workflows and jobs:"
 	@act -l
 
 .PHONY: test-claude-review
 test-claude-review: ## Test Claude code review workflow locally
-	@command -v act >/dev/null 2>&1 || { echo "act is not installed. Run: brew install act"; exit 1; }
+	@command -v act >/dev/null 2>&1 || { echo "act is not installed. See installation instructions at: https://github.com/nektos/act#installation"; exit 1; }
 	@if [ ! -f .secrets ]; then \
 		echo "Creating .secrets file template..."; \
 		echo "ANTHROPIC_API_KEY=your-api-key-here" > .secrets; \
@@ -287,7 +287,7 @@ test-claude-review: ## Test Claude code review workflow locally
 
 .PHONY: test-linear-sync
 test-linear-sync: ## Test Linear sync workflow locally
-	@command -v act >/dev/null 2>&1 || { echo "act is not installed. Run: brew install act"; exit 1; }
+	@command -v act >/dev/null 2>&1 || { echo "act is not installed. See installation instructions at: https://github.com/nektos/act#installation"; exit 1; }
 	@if [ ! -f .secrets ]; then \
 		echo "Creating .secrets file template..."; \
 		echo "LINEAR_API_TOKEN=your-token-here" > .secrets; \
@@ -308,7 +308,7 @@ test-linear-sync: ## Test Linear sync workflow locally
 
 .PHONY: test-actions-dry
 test-actions-dry: ## Dry run of GitHub Actions (show what would be executed)
-	@command -v act >/dev/null 2>&1 || { echo "act is not installed. Run: brew install act"; exit 1; }
+	@command -v act >/dev/null 2>&1 || { echo "act is not installed. See installation instructions at: https://github.com/nektos/act#installation"; exit 1; }
 	act -n -l
 
 ##@ Release

--- a/pkg/performance/collectors/cpu_info.go
+++ b/pkg/performance/collectors/cpu_info.go
@@ -44,7 +44,15 @@ type CPUInfoCollector struct {
 // Compile-time interface check
 var _ performance.PointCollector = (*CPUInfoCollector)(nil)
 
-func NewCPUInfoCollector(logger logr.Logger, config performance.CollectionConfig) *CPUInfoCollector {
+func NewCPUInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*CPUInfoCollector, error) {
+	// Validate paths are absolute
+	if !filepath.IsAbs(config.HostProcPath) {
+		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	}
+	if !filepath.IsAbs(config.HostSysPath) {
+		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	}
+
 	capabilities := performance.CollectorCapabilities{
 		SupportsOneShot:    true,
 		SupportsContinuous: false,
@@ -64,7 +72,7 @@ func NewCPUInfoCollector(logger logr.Logger, config performance.CollectionConfig
 		cpuinfoPath:    filepath.Join(config.HostProcPath, "cpuinfo"),
 		cpufreqPath:    filepath.Join(config.HostSysPath, "devices", "system", "cpu"),
 		nodeSystemPath: filepath.Join(config.HostSysPath, "devices", "system", "node"),
-	}
+	}, nil
 }
 
 func (c *CPUInfoCollector) Collect(ctx context.Context) (any, error) {

--- a/pkg/performance/collectors/cpu_info.go
+++ b/pkg/performance/collectors/cpu_info.go
@@ -45,12 +45,9 @@ type CPUInfoCollector struct {
 var _ performance.PointCollector = (*CPUInfoCollector)(nil)
 
 func NewCPUInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*CPUInfoCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
-	}
-	if !filepath.IsAbs(config.HostSysPath) {
-		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/cpu_info_test.go
+++ b/pkg/performance/collectors/cpu_info_test.go
@@ -271,13 +271,12 @@ func TestCPUInfoCollector_Constructor(t *testing.T) {
 			errMsg:  "HostSysPath must be an absolute path",
 		},
 		{
-			name: "empty paths",
+			name: "empty paths (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostProcPath: "",
 				HostSysPath:  "",
 			},
-			wantErr: true,
-			errMsg:  "HostProcPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/cpu_info_test.go
+++ b/pkg/performance/collectors/cpu_info_test.go
@@ -232,7 +232,68 @@ func createTestCPUInfoCollector(t *testing.T) (*collectors.CPUInfoCollector, str
 		HostSysPath:  sysPath,
 	}
 
-	return collectors.NewCPUInfoCollector(logr.Discard(), config), tmpDir
+	collector, err := collectors.NewCPUInfoCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector, tmpDir
+}
+
+func TestCPUInfoCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  performance.CollectionConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid absolute paths",
+			config: performance.CollectionConfig{
+				HostProcPath: "/proc",
+				HostSysPath:  "/sys",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid relative proc path",
+			config: performance.CollectionConfig{
+				HostProcPath: "proc",
+				HostSysPath:  "/sys",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+		{
+			name: "invalid relative sys path",
+			config: performance.CollectionConfig{
+				HostProcPath: "/proc",
+				HostSysPath:  "sys",
+			},
+			wantErr: true,
+			errMsg:  "HostSysPath must be an absolute path",
+		},
+		{
+			name: "empty paths",
+			config: performance.CollectionConfig{
+				HostProcPath: "",
+				HostSysPath:  "",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := collectors.NewCPUInfoCollector(logr.Discard(), tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, collector)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, collector)
+			}
+		})
+	}
 }
 
 func TestCPUInfoCollector_Collect(t *testing.T) {

--- a/pkg/performance/collectors/disk.go
+++ b/pkg/performance/collectors/disk.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Compile-time interface check
-var _ performance.Collector = (*DiskCollector)(nil)
+var _ performance.PointCollector = (*DiskCollector)(nil)
 
 const (
 	// diskstatsFieldCount is the expected number of fields in /proc/diskstats
@@ -42,7 +42,12 @@ type DiskCollector struct {
 	diskstatsPath string
 }
 
-func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) *DiskCollector {
+func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) (*DiskCollector, error) {
+	// Validate paths are absolute
+	if !filepath.IsAbs(config.HostProcPath) {
+		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	}
+
 	capabilities := performance.CollectorCapabilities{
 		SupportsOneShot:    true,
 		SupportsContinuous: false,
@@ -60,7 +65,7 @@ func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) *
 			capabilities,
 		),
 		diskstatsPath: filepath.Join(config.HostProcPath, "diskstats"),
-	}
+	}, nil
 }
 
 // Collect performs a one-shot collection of disk statistics

--- a/pkg/performance/collectors/disk.go
+++ b/pkg/performance/collectors/disk.go
@@ -43,9 +43,9 @@ type DiskCollector struct {
 }
 
 func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) (*DiskCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/disk_info.go
+++ b/pkg/performance/collectors/disk_info.go
@@ -67,7 +67,12 @@ type DiskInfoCollector struct {
 // Compile-time interface check
 var _ performance.PointCollector = (*DiskInfoCollector)(nil)
 
-func NewDiskInfoCollector(logger logr.Logger, config performance.CollectionConfig) *DiskInfoCollector {
+func NewDiskInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*DiskInfoCollector, error) {
+	// Validate paths are absolute
+	if !filepath.IsAbs(config.HostSysPath) {
+		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	}
+
 	capabilities := performance.CollectorCapabilities{
 		SupportsOneShot:    true,
 		SupportsContinuous: false,
@@ -85,7 +90,7 @@ func NewDiskInfoCollector(logger logr.Logger, config performance.CollectionConfi
 			capabilities,
 		),
 		blockPath: filepath.Join(config.HostSysPath, "block"),
-	}
+	}, nil
 }
 
 func (c *DiskInfoCollector) Collect(ctx context.Context) (any, error) {
@@ -120,7 +125,7 @@ func (c *DiskInfoCollector) collectDiskInfo() ([]performance.DiskInfo, error) {
 		// We need to check if the target is a directory, not just if the entry itself is
 		deviceName := entry.Name()
 		devicePath := filepath.Join(c.blockPath, deviceName)
-		
+
 		// Check if this path (following symlinks) is a directory
 		info, err := os.Stat(devicePath)
 		if err != nil || !info.IsDir() {

--- a/pkg/performance/collectors/disk_info.go
+++ b/pkg/performance/collectors/disk_info.go
@@ -68,9 +68,9 @@ type DiskInfoCollector struct {
 var _ performance.PointCollector = (*DiskInfoCollector)(nil)
 
 func NewDiskInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*DiskInfoCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostSysPath) {
-		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/disk_info_test.go
+++ b/pkg/performance/collectors/disk_info_test.go
@@ -84,12 +84,11 @@ func TestDiskInfoCollector_Constructor(t *testing.T) {
 			errMsg:  "HostSysPath must be an absolute path",
 		},
 		{
-			name: "empty path",
+			name: "empty path (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostSysPath: "",
 			},
-			wantErr: true,
-			errMsg:  "HostSysPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/disk_info_test.go
+++ b/pkg/performance/collectors/disk_info_test.go
@@ -29,7 +29,9 @@ func createTestDiskInfoCollector(t *testing.T) (*collectors.DiskInfoCollector, s
 		HostSysPath: sysPath,
 	}
 
-	return collectors.NewDiskInfoCollector(logr.Discard(), config), tmpDir
+	collector, err := collectors.NewDiskInfoCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector, tmpDir
 }
 
 func setupDiskDevice(t *testing.T, blockPath, device string, props map[string]string) {
@@ -56,6 +58,53 @@ func setupDiskDevice(t *testing.T, blockPath, device string, props map[string]st
 		if err := os.MkdirAll(dir, 0755); err == nil {
 			require.NoError(t, os.WriteFile(filePath, []byte(value), 0644))
 		}
+	}
+}
+
+func TestDiskInfoCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  performance.CollectionConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid absolute path",
+			config: performance.CollectionConfig{
+				HostSysPath: "/sys",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid relative path",
+			config: performance.CollectionConfig{
+				HostSysPath: "sys",
+			},
+			wantErr: true,
+			errMsg:  "HostSysPath must be an absolute path",
+		},
+		{
+			name: "empty path",
+			config: performance.CollectionConfig{
+				HostSysPath: "",
+			},
+			wantErr: true,
+			errMsg:  "HostSysPath must be an absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := collectors.NewDiskInfoCollector(logr.Discard(), tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, collector)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, collector)
+			}
+		})
 	}
 }
 

--- a/pkg/performance/collectors/disk_test.go
+++ b/pkg/performance/collectors/disk_test.go
@@ -51,7 +51,9 @@ func createDiskCollector(t *testing.T, procPath string) *collectors.DiskCollecto
 	config := performance.CollectionConfig{
 		HostProcPath: procPath,
 	}
-	return collectors.NewDiskCollector(logr.Discard(), config)
+	collector, err := collectors.NewDiskCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector
 }
 
 func setupDiskstatsFile(t *testing.T, content string) string {
@@ -78,6 +80,53 @@ func collectDiskStatsWithError(t *testing.T, collector *collectors.DiskCollector
 }
 
 // Test basic functionality
+func TestDiskCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  performance.CollectionConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid absolute path",
+			config: performance.CollectionConfig{
+				HostProcPath: "/proc",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid relative path",
+			config: performance.CollectionConfig{
+				HostProcPath: "proc",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+		{
+			name: "empty path",
+			config: performance.CollectionConfig{
+				HostProcPath: "",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := collectors.NewDiskCollector(logr.Discard(), tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, collector)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, collector)
+			}
+		})
+	}
+}
+
 func TestDiskCollector_BasicFunctionality(t *testing.T) {
 	procPath := setupDiskstatsFile(t, validDiskstats)
 	collector := createDiskCollector(t, procPath)

--- a/pkg/performance/collectors/disk_test.go
+++ b/pkg/performance/collectors/disk_test.go
@@ -103,12 +103,11 @@ func TestDiskCollector_Constructor(t *testing.T) {
 			errMsg:  "HostProcPath must be an absolute path",
 		},
 		{
-			name: "empty path",
+			name: "empty path (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostProcPath: "",
 			},
-			wantErr: true,
-			errMsg:  "HostProcPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/kernel.go
+++ b/pkg/performance/collectors/kernel.go
@@ -76,12 +76,9 @@ func WithMessageLimit(limit int) KernelCollectorOption {
 }
 
 func NewKernelCollector(logger logr.Logger, config performance.CollectionConfig, opts ...KernelCollectorOption) (*KernelCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostDevPath) {
-		return nil, fmt.Errorf("HostDevPath must be an absolute path, got: %q", config.HostDevPath)
-	}
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/kernel_test.go
+++ b/pkg/performance/collectors/kernel_test.go
@@ -53,13 +53,12 @@ func TestKernelCollector_Constructor(t *testing.T) {
 			errMsg:  "HostDevPath must be an absolute path",
 		},
 		{
-			name: "empty paths",
+			name: "empty paths (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostProcPath: "",
 				HostDevPath:  "",
 			},
-			wantErr: true,
-			errMsg:  "HostDevPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/load.go
+++ b/pkg/performance/collectors/load.go
@@ -39,11 +39,12 @@ func NewLoadCollector(logger logr.Logger, config performance.CollectionConfig) (
 		MinKernelVersion:   "2.6.0", // /proc/loadavg has been around forever
 	}
 
-	// Validate that HostProcPath is absolute and exists
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
+	// LoadCollector additionally checks for path existence
 	if _, err := os.Stat(config.HostProcPath); err != nil {
 		return nil, fmt.Errorf("HostProcPath validation failed: %w", err)
 	}

--- a/pkg/performance/collectors/load.go
+++ b/pkg/performance/collectors/load.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Compile-time interface check
-var _ performance.Collector = (*LoadCollector)(nil)
+var _ performance.PointCollector = (*LoadCollector)(nil)
 
 // LoadCollector collects system load statistics from /proc/loadavg and /proc/uptime
 // Reference: https://www.kernel.org/doc/html/latest/filesystems/proc.html#proc-loadavg

--- a/pkg/performance/collectors/load_test.go
+++ b/pkg/performance/collectors/load_test.go
@@ -1,3 +1,9 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package collectors_test
 
 import (
@@ -79,7 +85,8 @@ func TestLoadCollector_Constructor(t *testing.T) {
 		config := performance.CollectionConfig{HostProcPath: ""}
 		_, err := collectors.NewLoadCollector(logr.Discard(), config)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "must be an absolute path")
+		// LoadCollector does additional existence check after validation
+		assert.Contains(t, err.Error(), "HostProcPath validation failed")
 	})
 
 	t.Run("error on non-existent path", func(t *testing.T) {

--- a/pkg/performance/collectors/memory.go
+++ b/pkg/performance/collectors/memory.go
@@ -60,9 +60,9 @@ type MemoryCollector struct {
 }
 
 func NewMemoryCollector(logger logr.Logger, config performance.CollectionConfig) (*MemoryCollector, error) {
-	// Validate that HostProcPath is absolute
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/memory.go
+++ b/pkg/performance/collectors/memory.go
@@ -1,0 +1,263 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+)
+
+// Compile-time interface check
+var _ performance.Collector = (*MemoryCollector)(nil)
+
+// MemoryCollector collects runtime memory statistics from /proc/meminfo
+//
+// Purpose: Runtime memory monitoring and performance analysis
+// This collector provides real-time memory usage statistics for operational
+// monitoring, alerting, and performance analysis. It captures the current
+// state of system memory allocation and usage.
+//
+// This collector reads 30 memory statistics fields from /proc/meminfo, including:
+// - Basic memory usage (MemTotal, MemFree, MemAvailable)
+// - Buffer and cache memory
+// - Swap memory statistics
+// - Kernel memory usage (Slab, KernelStack, PageTables)
+// - Huge pages statistics
+// - Virtual memory statistics
+//
+// Key Differences from MemoryInfoCollector:
+// - MemoryCollector: Provides runtime statistics (dynamic, changes constantly)
+// - MemoryInfoCollector: Provides hardware configuration (static NUMA topology)
+// - This collector is for monitoring; MemoryInfoCollector is for inventory
+//
+// All memory values are converted from kilobytes (as reported by the kernel)
+// to bytes for consistency. HugePages counts are converted to bytes using
+// the reported Hugepagesize.
+//
+// Use Cases:
+// - Monitor memory pressure and usage patterns
+// - Detect memory leaks
+// - Alert on low memory conditions
+// - Analyze application memory behavior
+// - Track swap usage and page cache efficiency
+//
+// Reference: https://www.kernel.org/doc/html/latest/filesystems/proc.html#meminfo
+type MemoryCollector struct {
+	performance.BaseCollector
+	meminfoPath string
+}
+
+func NewMemoryCollector(logger logr.Logger, config performance.CollectionConfig) (*MemoryCollector, error) {
+	// Validate that HostProcPath is absolute
+	if !filepath.IsAbs(config.HostProcPath) {
+		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	}
+
+	capabilities := performance.CollectorCapabilities{
+		SupportsOneShot:    true,
+		SupportsContinuous: false,
+		RequiresRoot:       false,
+		RequiresEBPF:       false,
+		MinKernelVersion:   "2.6.0", // /proc/meminfo has been around forever
+	}
+
+	return &MemoryCollector{
+		BaseCollector: performance.NewBaseCollector(
+			performance.MetricTypeMemory,
+			"System Memory Collector",
+			logger,
+			config,
+			capabilities,
+		),
+		meminfoPath: filepath.Join(config.HostProcPath, "meminfo"),
+	}, nil
+}
+
+// Collect performs a one-shot collection of memory statistics
+func (c *MemoryCollector) Collect(ctx context.Context) (any, error) {
+	stats, err := c.collectMemoryStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect memory stats: %w", err)
+	}
+
+	c.Logger().V(1).Info("Collected memory statistics")
+	return stats, nil
+}
+
+// collectMemoryStats reads and parses runtime memory statistics from /proc/meminfo
+//
+// This method collects current memory usage and state information for performance
+// monitoring. Unlike MemoryInfoCollector which only reads MemTotal for hardware
+// inventory, this reads all available memory statistics for operational monitoring.
+//
+// /proc/meminfo format:
+//   FieldName:       value kB
+//
+// Most fields are in kilobytes, except HugePages_* which are page counts.
+// The collector converts all values to bytes for consistency.
+//
+// Error handling:
+// - File read errors return an error (critical failure)
+// - Individual field parsing errors are logged but don't fail collection
+// - Missing fields are left as zero (graceful degradation)
+func (c *MemoryCollector) collectMemoryStats() (*performance.MemoryStats, error) {
+	file, err := os.Open(c.meminfoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", c.meminfoPath, err)
+	}
+	defer file.Close()
+
+	stats := &performance.MemoryStats{}
+	scanner := bufio.NewScanner(file)
+
+	// Map field names from /proc/meminfo to struct fields
+	fieldMap := map[string]*uint64{
+		"MemTotal":     &stats.MemTotal,
+		"MemFree":      &stats.MemFree,
+		"MemAvailable": &stats.MemAvailable,
+		"Buffers":      &stats.Buffers,
+		"Cached":       &stats.Cached,
+		"SwapCached":   &stats.SwapCached,
+		"Active":       &stats.Active,
+		"Inactive":     &stats.Inactive,
+		"SwapTotal":    &stats.SwapTotal,
+		"SwapFree":     &stats.SwapFree,
+		"Dirty":        &stats.Dirty,
+		"Writeback":    &stats.Writeback,
+		"AnonPages":    &stats.AnonPages,
+		"Mapped":       &stats.Mapped,
+		"Shmem":        &stats.Shmem,
+		"Slab":         &stats.Slab,
+		"SReclaimable": &stats.SReclaimable,
+		"SUnreclaim":   &stats.SUnreclaim,
+		"KernelStack":  &stats.KernelStack,
+		"PageTables":   &stats.PageTables,
+		"CommitLimit":  &stats.CommitLimit,
+		"Committed_AS": &stats.CommittedAS,
+		"VmallocTotal": &stats.VmallocTotal,
+		"VmallocUsed":  &stats.VmallocUsed,
+		// https://www.kernel.org/doc/html/latest/admin-guide/mm/hugetlbpage.html
+		"HugePages_Total": &stats.HugePages_Total,
+		"HugePages_Free":  &stats.HugePages_Free,
+		"HugePages_Rsvd":  &stats.HugePages_Rsvd,
+		"HugePages_Surp":  &stats.HugePages_Surp,
+		"Hugepagesize":    &stats.HugePagesize,
+		"Hugetlb":         &stats.Hugetlb,
+	}
+
+	// Track huge page counts and size for proper conversion
+	hugePagesCountFields := map[string]bool{
+		"HugePages_Total": true,
+		"HugePages_Free":  true,
+		"HugePages_Rsvd":  true,
+		"HugePages_Surp":  true,
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Lines are formatted as "FieldName:   value kB"
+		// Some fields might have additional info after the unit
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		// Remove trailing colon from field name
+		fieldName := strings.TrimSuffix(parts[0], ":")
+
+		// Check if this is a field we're interested in
+		fieldPtr, ok := fieldMap[fieldName]
+		if !ok {
+			continue
+		}
+
+		// Parse the value (second field is always the numeric value)
+		value, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			// Log at debug level - some fields might have different formats on certain systems
+			c.Logger().V(2).Info("Failed to parse memory field value",
+				"field", fieldName, "value", parts[1], "error", err)
+			continue
+		}
+
+		// Store raw value first
+		*fieldPtr = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", c.meminfoPath, err)
+	}
+
+	// Post-process: convert values to bytes
+	c.convertToBytes(stats, hugePagesCountFields)
+
+	return stats, nil
+}
+
+// convertToBytes converts memory values from their native units to bytes
+//
+// Most /proc/meminfo fields are in kilobytes and need to be multiplied by 1024.
+// HugePages fields are special:
+// - HugePages_Total, HugePages_Free, HugePages_Rsvd, HugePages_Surp are page counts
+// - These counts are multiplied by Hugepagesize to get total bytes
+// - Hugepagesize itself is in kB and converted to bytes
+// - Hugetlb is already a memory amount in kB, not a page count
+func (c *MemoryCollector) convertToBytes(stats *performance.MemoryStats, hugePagesCountFields map[string]bool) {
+	// Convert regular kB fields to bytes
+	stats.MemTotal *= 1024
+	stats.MemFree *= 1024
+	stats.MemAvailable *= 1024
+	stats.Buffers *= 1024
+	stats.Cached *= 1024
+	stats.SwapCached *= 1024
+	stats.Active *= 1024
+	stats.Inactive *= 1024
+	stats.SwapTotal *= 1024
+	stats.SwapFree *= 1024
+	stats.Dirty *= 1024
+	stats.Writeback *= 1024
+	stats.AnonPages *= 1024
+	stats.Mapped *= 1024
+	stats.Shmem *= 1024
+	stats.Slab *= 1024
+	stats.SReclaimable *= 1024
+	stats.SUnreclaim *= 1024
+	stats.KernelStack *= 1024
+	stats.PageTables *= 1024
+	stats.CommitLimit *= 1024
+	stats.CommittedAS *= 1024
+	stats.VmallocTotal *= 1024
+	stats.VmallocUsed *= 1024
+
+	// Convert Hugepagesize from kB to bytes
+	stats.HugePagesize *= 1024
+
+	// Convert Hugetlb from kB to bytes (this is already a total memory amount)
+	stats.Hugetlb *= 1024
+
+	// Convert huge page counts to bytes using the huge page size
+	// HugePages_Total, HugePages_Free, HugePages_Rsvd, HugePages_Surp are counts, not sizes
+	// They should be multiplied by the huge page size to get total memory
+	//
+	// Note: /proc/meminfo shows the default huge page size and counts.
+	// To see all supported huge page sizes, check: /sys/kernel/mm/hugepages/
+	// Each subdirectory (e.g., hugepages-2048kB) contains size-specific counts.
+	if stats.HugePagesize > 0 {
+		stats.HugePages_Total *= stats.HugePagesize
+		stats.HugePages_Free *= stats.HugePagesize
+		stats.HugePages_Rsvd *= stats.HugePagesize
+		stats.HugePages_Surp *= stats.HugePagesize
+	}
+}

--- a/pkg/performance/collectors/memory.go
+++ b/pkg/performance/collectors/memory.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Compile-time interface check
-var _ performance.Collector = (*MemoryCollector)(nil)
+var _ performance.PointCollector = (*MemoryCollector)(nil)
 
 // MemoryCollector collects runtime memory statistics from /proc/meminfo
 //
@@ -103,7 +103,8 @@ func (c *MemoryCollector) Collect(ctx context.Context) (any, error) {
 // inventory, this reads all available memory statistics for operational monitoring.
 //
 // /proc/meminfo format:
-//   FieldName:       value kB
+//
+//	FieldName:       value kB
 //
 // Most fields are in kilobytes, except HugePages_* which are page counts.
 // The collector converts all values to bytes for consistency.

--- a/pkg/performance/collectors/memory_info.go
+++ b/pkg/performance/collectors/memory_info.go
@@ -97,12 +97,9 @@ type MemoryInfoCollector struct {
 var _ performance.PointCollector = (*MemoryInfoCollector)(nil)
 
 func NewMemoryInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*MemoryInfoCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
-	}
-	if !filepath.IsAbs(config.HostSysPath) {
-		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/memory_info.go
+++ b/pkg/performance/collectors/memory_info.go
@@ -19,7 +19,25 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// MemoryInfoCollector collects memory hardware configuration from the Linux proc and sysfs filesystems.
+// MemoryInfoCollector collects memory hardware configuration and NUMA topology.
+//
+// Purpose: Hardware inventory and NUMA topology discovery
+// This collector provides static memory hardware configuration for capacity
+// planning, NUMA-aware scheduling, and hardware inventory. It discovers the
+// physical memory architecture rather than runtime usage.
+//
+// Key Differences from MemoryCollector:
+// - MemoryInfoCollector: Provides hardware configuration (static NUMA topology)
+// - MemoryCollector: Provides runtime statistics (dynamic memory usage)
+// - This collector is for inventory; MemoryCollector is for monitoring
+// - Reads only MemTotal from /proc/meminfo, focuses on NUMA topology from sysfs
+//
+// Use Cases:
+// - Hardware inventory and asset tracking
+// - NUMA-aware application deployment
+// - Capacity planning and sizing
+// - Understanding system memory architecture
+// - Optimizing memory access patterns
 //
 // Data Sources and Standardization:
 //
@@ -144,8 +162,13 @@ func (c *MemoryInfoCollector) collectMemoryInfo() (*performance.MemoryInfo, erro
 //
 // Data Source: /proc/meminfo (KERNEL-GUARANTEED)
 //
-// This method reads the MemTotal field from /proc/meminfo, which represents the total
-// amount of usable RAM as detected and managed by the kernel memory management system.
+// This method reads ONLY the MemTotal field from /proc/meminfo for hardware
+// inventory purposes. This is the only field MemoryInfoCollector reads from
+// /proc/meminfo, as it focuses on hardware configuration rather than runtime
+// statistics (which are handled by MemoryCollector).
+//
+// The MemTotal value represents the total amount of usable RAM as detected
+// and managed by the kernel memory management system.
 //
 // Format Specification:
 // - File format: "MemTotal: XXXXX kB" (always in kilobytes)

--- a/pkg/performance/collectors/memory_info.go
+++ b/pkg/performance/collectors/memory_info.go
@@ -96,7 +96,15 @@ type MemoryInfoCollector struct {
 // Compile-time interface check
 var _ performance.PointCollector = (*MemoryInfoCollector)(nil)
 
-func NewMemoryInfoCollector(logger logr.Logger, config performance.CollectionConfig) *MemoryInfoCollector {
+func NewMemoryInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*MemoryInfoCollector, error) {
+	// Validate paths are absolute
+	if !filepath.IsAbs(config.HostProcPath) {
+		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	}
+	if !filepath.IsAbs(config.HostSysPath) {
+		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	}
+
 	capabilities := performance.CollectorCapabilities{
 		SupportsOneShot:    true,
 		SupportsContinuous: false,
@@ -115,7 +123,7 @@ func NewMemoryInfoCollector(logger logr.Logger, config performance.CollectionCon
 		),
 		meminfoPath:    filepath.Join(config.HostProcPath, "meminfo"),
 		nodeSystemPath: filepath.Join(config.HostSysPath, "devices", "system", "node"),
-	}
+	}, nil
 }
 
 func (c *MemoryInfoCollector) Collect(ctx context.Context) (any, error) {

--- a/pkg/performance/collectors/memory_info_test.go
+++ b/pkg/performance/collectors/memory_info_test.go
@@ -89,13 +89,12 @@ func TestMemoryInfoCollector_Constructor(t *testing.T) {
 			errMsg:  "HostSysPath must be an absolute path",
 		},
 		{
-			name: "empty paths",
+			name: "empty paths (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostProcPath: "",
 				HostSysPath:  "",
 			},
-			wantErr: true,
-			errMsg:  "HostProcPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/memory_test.go
+++ b/pkg/performance/collectors/memory_test.go
@@ -1,0 +1,593 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package collectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/antimetal/agent/pkg/performance"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Valid scenarios
+	validMeminfoContent = `MemTotal:        8192000 kB
+MemFree:         1024000 kB
+MemAvailable:    4096000 kB
+Buffers:          256000 kB
+Cached:          2048000 kB
+SwapCached:       128000 kB
+Active:          3072000 kB
+Inactive:        2048000 kB
+SwapTotal:       4096000 kB
+SwapFree:        3072000 kB
+Dirty:             16384 kB
+Writeback:             0 kB
+AnonPages:       1536000 kB
+Mapped:           512000 kB
+Shmem:            128000 kB
+Slab:             256000 kB
+SReclaimable:     128000 kB
+SUnreclaim:       128000 kB
+KernelStack:       16384 kB
+PageTables:        32768 kB
+CommitLimit:     8192000 kB
+Committed_AS:    5120000 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      524288 kB
+HugePages_Total:       0
+HugePages_Free:        0
+Hugepagesize:       2048 kB
+`
+
+	partialMeminfoContent = `MemTotal:        8192000 kB
+MemFree:         1024000 kB
+Buffers:          256000 kB
+Cached:          2048000 kB
+SwapTotal:       4096000 kB
+SwapFree:        3072000 kB
+`
+
+	// Edge cases
+	zeroValuesMeminfoContent = `MemTotal:        0 kB
+MemFree:         0 kB
+MemAvailable:    0 kB
+Buffers:          0 kB
+Cached:          0 kB
+SwapTotal:       0 kB
+SwapFree:        0 kB
+`
+
+	// Boundary conditions
+	highMemoryMeminfoContent = `MemTotal:        134217728 kB
+MemFree:         67108864 kB
+MemAvailable:    100663296 kB
+Buffers:         16777216 kB
+Cached:          33554432 kB
+SwapTotal:       67108864 kB
+SwapFree:        33554432 kB
+`
+
+	hugePagesMeminfoContent = `MemTotal:        8192000 kB
+MemFree:         1024000 kB
+MemAvailable:    4096000 kB
+Buffers:          256000 kB
+Cached:          2048000 kB
+SwapTotal:       4096000 kB
+SwapFree:        3072000 kB
+HugePages_Total:    1024
+HugePages_Free:      512
+HugePages_Rsvd:      256
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:         2097152 kB
+DirectMap4k:      524288 kB
+DirectMap2M:     7340032 kB
+DirectMap1G:           0 kB
+`
+
+	// Comprehensive meminfo with all supported fields
+	comprehensiveValidMeminfoContent = `MemTotal:        16777216 kB
+MemFree:          8388608 kB
+MemAvailable:    12582912 kB
+Buffers:           524288 kB
+Cached:           4194304 kB
+SwapCached:        262144 kB
+Active:           6291456 kB
+Inactive:         4194304 kB
+SwapTotal:        8388608 kB
+SwapFree:         6291456 kB
+Dirty:              32768 kB
+Writeback:              0 kB
+AnonPages:        3145728 kB
+Mapped:           1048576 kB
+Shmem:             262144 kB
+Slab:              524288 kB
+SReclaimable:      262144 kB
+SUnreclaim:        262144 kB
+KernelStack:        32768 kB
+PageTables:         65536 kB
+CommitLimit:    16777216 kB
+Committed_AS:   10485760 kB
+VmallocTotal:   68719476735 kB
+VmallocUsed:     1048576 kB
+HugePages_Total:    2048
+HugePages_Free:     1024
+HugePages_Rsvd:      512
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:         4194304 kB
+`
+
+	// Error conditions
+	malformedMeminfoContent = `MemTotal: invalid_value kB
+MemFree:         1024000 kB
+`
+
+	invalidUnitMeminfoContent = `MemTotal:        8192000 MB
+MemFree:         1024000 kB
+`
+
+	missingColonMeminfoContent = `MemTotal        8192000 kB
+MemFree         1024000 kB
+`
+
+	emptyMeminfoContent = ``
+
+	mixedValidInvalidContent = `MemTotal:        8192000 kB
+MemFree:         invalid_value kB
+MemAvailable:    4096000 kB
+Buffers:          256000 kB
+`
+
+	// Boundary value test constants
+	maxValuesMeminfoContent = `MemTotal:        18446744073709551615 kB
+MemFree:         18446744073709551615 kB
+MemAvailable:    18446744073709551615 kB
+Buffers:         18446744073709551615 kB
+Cached:          18446744073709551615 kB
+SwapTotal:       18446744073709551615 kB
+SwapFree:        18446744073709551615 kB
+`
+
+	overflowMeminfoContent = `MemTotal:        18446744073709551616 kB
+MemFree:         1024000 kB
+MemAvailable:    4096000 kB
+Buffers:          256000 kB
+`
+
+	largeMemoryMeminfoContent = `MemTotal:        1099511627776 kB
+MemFree:         549755813888 kB
+MemAvailable:    824633720832 kB
+Buffers:         68719476736 kB
+Cached:          274877906944 kB
+SwapTotal:       549755813888 kB
+SwapFree:        274877906944 kB
+`
+
+	singleKbValueMeminfoContent = `MemTotal:        1 kB
+MemFree:         1 kB
+MemAvailable:    1 kB
+Buffers:          1 kB
+Cached:           1 kB
+SwapTotal:        1 kB
+SwapFree:         1 kB
+`
+)
+
+func createMemoryTestCollector(t *testing.T, meminfoContent string) *MemoryCollector {
+	tmpDir := t.TempDir()
+
+	meminfoPath := filepath.Join(tmpDir, "meminfo")
+	err := os.WriteFile(meminfoPath, []byte(meminfoContent), 0644)
+	require.NoError(t, err)
+
+	config := performance.CollectionConfig{
+		HostProcPath: tmpDir,
+		HostSysPath:  tmpDir,
+	}
+	collector, err := NewMemoryCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector
+}
+
+func createMemoryTestCollectorWithoutFile(t *testing.T) *MemoryCollector {
+	tmpDir := t.TempDir()
+
+	config := performance.CollectionConfig{
+		HostProcPath: tmpDir,
+		HostSysPath:  tmpDir,
+	}
+	collector, err := NewMemoryCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector
+}
+
+func validateMemoryCollectorInterface(t *testing.T, collector interface{}) {
+	_, ok := collector.(performance.Collector)
+	require.True(t, ok, "collector must implement Collector interface")
+}
+
+func validateMemoryStats(t *testing.T, stats *performance.MemoryStats, expected *performance.MemoryStats) {
+	assert.Equal(t, expected.MemTotal, stats.MemTotal)
+	assert.Equal(t, expected.MemFree, stats.MemFree)
+	assert.Equal(t, expected.MemAvailable, stats.MemAvailable)
+	assert.Equal(t, expected.Buffers, stats.Buffers)
+	assert.Equal(t, expected.Cached, stats.Cached)
+	assert.Equal(t, expected.SwapCached, stats.SwapCached)
+	assert.Equal(t, expected.Active, stats.Active)
+	assert.Equal(t, expected.Inactive, stats.Inactive)
+	assert.Equal(t, expected.SwapTotal, stats.SwapTotal)
+	assert.Equal(t, expected.SwapFree, stats.SwapFree)
+	assert.Equal(t, expected.Dirty, stats.Dirty)
+	assert.Equal(t, expected.Writeback, stats.Writeback)
+	assert.Equal(t, expected.AnonPages, stats.AnonPages)
+	assert.Equal(t, expected.Mapped, stats.Mapped)
+	assert.Equal(t, expected.Shmem, stats.Shmem)
+	assert.Equal(t, expected.Slab, stats.Slab)
+	assert.Equal(t, expected.SReclaimable, stats.SReclaimable)
+	assert.Equal(t, expected.SUnreclaim, stats.SUnreclaim)
+	assert.Equal(t, expected.KernelStack, stats.KernelStack)
+	assert.Equal(t, expected.PageTables, stats.PageTables)
+	assert.Equal(t, expected.CommitLimit, stats.CommitLimit)
+	assert.Equal(t, expected.CommittedAS, stats.CommittedAS)
+	assert.Equal(t, expected.VmallocTotal, stats.VmallocTotal)
+	assert.Equal(t, expected.VmallocUsed, stats.VmallocUsed)
+	assert.Equal(t, expected.HugePages_Total, stats.HugePages_Total)
+	assert.Equal(t, expected.HugePages_Free, stats.HugePages_Free)
+	assert.Equal(t, expected.HugePages_Rsvd, stats.HugePages_Rsvd)
+	assert.Equal(t, expected.HugePages_Surp, stats.HugePages_Surp)
+	assert.Equal(t, expected.HugePagesize, stats.HugePagesize)
+	assert.Equal(t, expected.Hugetlb, stats.Hugetlb)
+}
+
+func collectAndValidateMemory(t *testing.T, collector *MemoryCollector, wantErr bool) *performance.MemoryStats {
+	result, err := collector.Collect(context.Background())
+
+	if wantErr {
+		assert.Error(t, err)
+		return nil
+	}
+
+	require.NoError(t, err)
+	stats, ok := result.(*performance.MemoryStats)
+	require.True(t, ok)
+	return stats
+}
+
+func TestMemoryCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name                string
+		hostProcPath        string
+		expectedMeminfoPath string
+		wantErr             bool
+	}{
+		{"default proc path", "/proc", "/proc/meminfo", false},
+		{"custom proc path", "/custom/proc", "/custom/proc/meminfo", false},
+		{"relative proc path", "proc", "", true},
+		{"empty proc path", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := performance.CollectionConfig{
+				HostProcPath: tt.hostProcPath,
+				HostSysPath:  "/sys",
+			}
+			collector, err := NewMemoryCollector(logr.Discard(), config)
+			
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, collector)
+				return
+			}
+			
+			require.NoError(t, err)
+			require.NotNil(t, collector)
+			validateMemoryCollectorInterface(t, collector)
+			assert.Equal(t, tt.expectedMeminfoPath, collector.meminfoPath)
+		})
+	}
+}
+
+func TestMemoryCollector_AllFields(t *testing.T) {
+	collector := createMemoryTestCollector(t, comprehensiveValidMeminfoContent)
+	stats := collectAndValidateMemory(t, collector, false)
+
+	// Test all 26 supported fields with proper kB to bytes conversion
+	expectedFields := map[string]struct {
+		got      uint64
+		expected uint64
+		name     string
+	}{
+		"MemTotal":     {stats.MemTotal, 16777216 * 1024, "MemTotal"},
+		"MemFree":      {stats.MemFree, 8388608 * 1024, "MemFree"},
+		"MemAvailable": {stats.MemAvailable, 12582912 * 1024, "MemAvailable"},
+		"Buffers":      {stats.Buffers, 524288 * 1024, "Buffers"},
+		"Cached":       {stats.Cached, 4194304 * 1024, "Cached"},
+		"SwapCached":   {stats.SwapCached, 262144 * 1024, "SwapCached"},
+		"Active":       {stats.Active, 6291456 * 1024, "Active"},
+		"Inactive":     {stats.Inactive, 4194304 * 1024, "Inactive"},
+		"SwapTotal":    {stats.SwapTotal, 8388608 * 1024, "SwapTotal"},
+		"SwapFree":     {stats.SwapFree, 6291456 * 1024, "SwapFree"},
+		"Dirty":        {stats.Dirty, 32768 * 1024, "Dirty"},
+		"Writeback":    {stats.Writeback, 0, "Writeback"},
+		"AnonPages":    {stats.AnonPages, 3145728 * 1024, "AnonPages"},
+		"Mapped":       {stats.Mapped, 1048576 * 1024, "Mapped"},
+		"Shmem":        {stats.Shmem, 262144 * 1024, "Shmem"},
+		"Slab":         {stats.Slab, 524288 * 1024, "Slab"},
+		"SReclaimable": {stats.SReclaimable, 262144 * 1024, "SReclaimable"},
+		"SUnreclaim":   {stats.SUnreclaim, 262144 * 1024, "SUnreclaim"},
+		"KernelStack":  {stats.KernelStack, 32768 * 1024, "KernelStack"},
+		"PageTables":   {stats.PageTables, 65536 * 1024, "PageTables"},
+		"CommitLimit":  {stats.CommitLimit, 16777216 * 1024, "CommitLimit"},
+		"CommittedAS":  {stats.CommittedAS, 10485760 * 1024, "CommittedAS"},
+		"VmallocTotal": {stats.VmallocTotal, 68719476735 * 1024, "VmallocTotal"},
+		"VmallocUsed":  {stats.VmallocUsed, 1048576 * 1024, "VmallocUsed"},
+		// HugePages fields are converted from counts to bytes using HugePagesize
+		"HugePages_Total": {stats.HugePages_Total, 2048 * (2048 * 1024), "HugePages_Total"}, // 2048 pages * 2048 kB * 1024 bytes/kB
+		"HugePages_Free":  {stats.HugePages_Free, 1024 * (2048 * 1024), "HugePages_Free"},   // 1024 pages * 2048 kB * 1024 bytes/kB
+		"HugePages_Rsvd":  {stats.HugePages_Rsvd, 512 * (2048 * 1024), "HugePages_Rsvd"},    // 512 pages * 2048 kB * 1024 bytes/kB
+		"HugePages_Surp":  {stats.HugePages_Surp, 0 * (2048 * 1024), "HugePages_Surp"},      // 0 pages * 2048 kB * 1024 bytes/kB
+		"HugePagesize":    {stats.HugePagesize, 2048 * 1024, "HugePagesize"},                // 2048 kB * 1024 bytes/kB
+		"Hugetlb":         {stats.Hugetlb, 4194304 * 1024, "Hugetlb"},                       // 4194304 kB * 1024 bytes/kB
+	}
+
+	// Validate each field
+	for _, expected := range expectedFields {
+		if expected.got != expected.expected {
+			t.Errorf("%s: got %d bytes, expected %d bytes (conversion from kB failed)",
+				expected.name, expected.got, expected.expected)
+		}
+	}
+
+	// Verify we're testing all 26+ supported fields
+	totalFields := len(expectedFields)
+	if totalFields < 26 {
+		t.Errorf("Expected to test at least 26 memory fields, but only tested %d", totalFields)
+	}
+
+	t.Logf("Successfully validated %d memory fields with proper kB to bytes conversion", totalFields)
+}
+
+func TestMemoryCollector_Comprehensive(t *testing.T) {
+	tests := []struct {
+		name           string
+		meminfoContent string
+		createFile     bool
+		wantErr        bool
+		expectedErr    string
+		expected       *performance.MemoryStats
+	}{
+		// Valid parsing cases
+		{
+			name:           "valid complete meminfo",
+			meminfoContent: validMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:        8192000 * 1024,
+				MemFree:         1024000 * 1024,
+				MemAvailable:    4096000 * 1024,
+				Buffers:         256000 * 1024,
+				Cached:          2048000 * 1024,
+				SwapCached:      128000 * 1024,
+				Active:          3072000 * 1024,
+				Inactive:        2048000 * 1024,
+				SwapTotal:       4096000 * 1024,
+				SwapFree:        3072000 * 1024,
+				Dirty:           16384 * 1024,
+				Writeback:       0,
+				AnonPages:       1536000 * 1024,
+				Mapped:          512000 * 1024,
+				Shmem:           128000 * 1024,
+				Slab:            256000 * 1024,
+				SReclaimable:    128000 * 1024,
+				SUnreclaim:      128000 * 1024,
+				KernelStack:     16384 * 1024,
+				PageTables:      32768 * 1024,
+				CommitLimit:     8192000 * 1024,
+				CommittedAS:     5120000 * 1024,
+				VmallocTotal:    34359738367 * 1024,
+				VmallocUsed:     524288 * 1024,
+				HugePages_Total: 0,
+				HugePages_Free:  0,
+				HugePagesize:    2048 * 1024,
+			},
+		},
+		{
+			name:           "huge pages data",
+			meminfoContent: hugePagesMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:        8192000 * 1024,
+				MemFree:         1024000 * 1024,
+				MemAvailable:    4096000 * 1024,
+				Buffers:         256000 * 1024,
+				Cached:          2048000 * 1024,
+				SwapTotal:       4096000 * 1024,
+				SwapFree:        3072000 * 1024,
+				HugePages_Total: 1024 * (2048 * 1024), // 1024 pages * 2048 kB per page * 1024 bytes per kB
+				HugePages_Free:  512 * (2048 * 1024),  // 512 pages * 2048 kB per page * 1024 bytes per kB
+				HugePages_Rsvd:  256 * (2048 * 1024),  // 256 pages * 2048 kB per page * 1024 bytes per kB
+				HugePages_Surp:  0 * (2048 * 1024),    // 0 pages * 2048 kB per page * 1024 bytes per kB
+				HugePagesize:    2048 * 1024,          // 2048 kB * 1024 bytes per kB
+				Hugetlb:         2097152 * 1024,       // 2097152 kB * 1024 bytes per kB
+			},
+		},
+		{
+			name:           "partial data (graceful degradation)",
+			meminfoContent: partialMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:  8192000 * 1024,
+				MemFree:   1024000 * 1024,
+				Buffers:   256000 * 1024,
+				Cached:    2048000 * 1024,
+				SwapTotal: 4096000 * 1024,
+				SwapFree:  3072000 * 1024,
+			},
+		},
+		// Boundary value cases
+		{
+			name:           "maximum uint64 values",
+			meminfoContent: maxValuesMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     ^uint64(0) & ^uint64(1023), // Max value rounded down to nearest KB boundary in bytes
+				MemFree:      ^uint64(0) & ^uint64(1023),
+				MemAvailable: ^uint64(0) & ^uint64(1023),
+				Buffers:      ^uint64(0) & ^uint64(1023),
+				Cached:       ^uint64(0) & ^uint64(1023),
+				SwapTotal:    ^uint64(0) & ^uint64(1023),
+				SwapFree:     ^uint64(0) & ^uint64(1023),
+			},
+		},
+		{
+			name:           "single kB values",
+			meminfoContent: singleKbValueMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     1024,
+				MemFree:      1024,
+				MemAvailable: 1024,
+				Buffers:      1024,
+				Cached:       1024,
+				SwapTotal:    1024,
+				SwapFree:     1024,
+			},
+		},
+		{
+			name:           "large memory system (1TB total)",
+			meminfoContent: largeMemoryMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     1099511627776 * 1024, // 1TB in bytes
+				MemFree:      549755813888 * 1024,  // 512GB in bytes
+				MemAvailable: 824633720832 * 1024,  // 768GB in bytes
+				Buffers:      68719476736 * 1024,   // 64GB in bytes
+				Cached:       274877906944 * 1024,  // 256GB in bytes
+				SwapTotal:    549755813888 * 1024,  // 512GB in bytes
+				SwapFree:     274877906944 * 1024,  // 256GB in bytes
+			},
+		},
+		{
+			name:           "zero values (minimal system)",
+			meminfoContent: zeroValuesMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     0,
+				MemFree:      0,
+				MemAvailable: 0,
+				Buffers:      0,
+				Cached:       0,
+				SwapTotal:    0,
+				SwapFree:     0,
+			},
+		},
+		{
+			name:           "high memory values",
+			meminfoContent: highMemoryMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     134217728 * 1024,
+				MemFree:      67108864 * 1024,
+				MemAvailable: 100663296 * 1024,
+				Buffers:      16777216 * 1024,
+				Cached:       33554432 * 1024,
+				SwapTotal:    67108864 * 1024,
+				SwapFree:     33554432 * 1024,
+			},
+		},
+		// Graceful degradation cases (collector continues on parse errors)
+		{
+			name:           "malformed numeric values (graceful degradation)",
+			meminfoContent: malformedMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemFree: 1024000 * 1024, // Only valid line is parsed
+			},
+		},
+		{
+			name:           "invalid units (graceful degradation)",
+			meminfoContent: invalidUnitMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal: 8192000 * 1024, // Parses number, ignores invalid unit
+				MemFree:  1024000 * 1024, // Valid line is parsed
+			},
+		},
+		{
+			name:           "missing colon separator (graceful degradation)",
+			meminfoContent: missingColonMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal: 8192000 * 1024, // Parses "MemTotal 8192000 kB" without colon
+				MemFree:  1024000 * 1024, // Parses "MemFree 1024000 kB" without colon
+			},
+		},
+		{
+			name:           "mixed valid and invalid lines (graceful degradation)",
+			meminfoContent: mixedValidInvalidContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemTotal:     8192000 * 1024, // Valid lines are parsed
+				MemAvailable: 4096000 * 1024,
+				Buffers:      256000 * 1024,
+			},
+		},
+		{
+			name:           "overflow value handling (graceful degradation)",
+			meminfoContent: overflowMeminfoContent,
+			createFile:     true,
+			expected: &performance.MemoryStats{
+				MemFree:      1024000 * 1024,
+				MemAvailable: 4096000 * 1024,
+				Buffers:      256000 * 1024,
+			},
+		},
+		{
+			name:           "empty file",
+			meminfoContent: emptyMeminfoContent,
+			createFile:     true,
+			expected:       &performance.MemoryStats{},
+		},
+		// Error cases
+		{
+			name:        "missing file",
+			createFile:  false,
+			wantErr:     true,
+			expectedErr: "failed to open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var collector *MemoryCollector
+			if tt.createFile {
+				collector = createMemoryTestCollector(t, tt.meminfoContent)
+			} else {
+				collector = createMemoryTestCollectorWithoutFile(t)
+			}
+
+			validateMemoryCollectorInterface(t, collector)
+			stats := collectAndValidateMemory(t, collector, tt.wantErr)
+
+			if tt.wantErr {
+				return
+			}
+
+			if tt.expected != nil {
+				validateMemoryStats(t, stats, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/performance/collectors/memory_test.go
+++ b/pkg/performance/collectors/memory_test.go
@@ -284,13 +284,13 @@ func TestMemoryCollector_Constructor(t *testing.T) {
 				HostSysPath:  "/sys",
 			}
 			collector, err := NewMemoryCollector(logr.Discard(), config)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, collector)
 				return
 			}
-			
+
 			require.NoError(t, err)
 			require.NotNil(t, collector)
 			validateMemoryCollectorInterface(t, collector)

--- a/pkg/performance/collectors/memory_test.go
+++ b/pkg/performance/collectors/memory_test.go
@@ -274,7 +274,7 @@ func TestMemoryCollector_Constructor(t *testing.T) {
 		{"default proc path", "/proc", "/proc/meminfo", false},
 		{"custom proc path", "/custom/proc", "/custom/proc/meminfo", false},
 		{"relative proc path", "proc", "", true},
-		{"empty proc path", "", "", true},
+		{"empty proc path", "", "meminfo", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/performance/collectors/network_info.go
+++ b/pkg/performance/collectors/network_info.go
@@ -66,7 +66,12 @@ type NetworkInfoCollector struct {
 // Compile-time interface check
 var _ performance.PointCollector = (*NetworkInfoCollector)(nil)
 
-func NewNetworkInfoCollector(logger logr.Logger, config performance.CollectionConfig) *NetworkInfoCollector {
+func NewNetworkInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*NetworkInfoCollector, error) {
+	// Validate paths are absolute
+	if !filepath.IsAbs(config.HostSysPath) {
+		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	}
+
 	capabilities := performance.CollectorCapabilities{
 		SupportsOneShot:    true,
 		SupportsContinuous: false,
@@ -84,7 +89,7 @@ func NewNetworkInfoCollector(logger logr.Logger, config performance.CollectionCo
 			capabilities,
 		),
 		netClassPath: filepath.Join(config.HostSysPath, "class", "net"),
-	}
+	}, nil
 }
 
 func (c *NetworkInfoCollector) Collect(ctx context.Context) (any, error) {

--- a/pkg/performance/collectors/network_info.go
+++ b/pkg/performance/collectors/network_info.go
@@ -67,9 +67,9 @@ type NetworkInfoCollector struct {
 var _ performance.PointCollector = (*NetworkInfoCollector)(nil)
 
 func NewNetworkInfoCollector(logger logr.Logger, config performance.CollectionConfig) (*NetworkInfoCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostSysPath) {
-		return nil, fmt.Errorf("HostSysPath must be an absolute path, got: %q", config.HostSysPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/network_info_test.go
+++ b/pkg/performance/collectors/network_info_test.go
@@ -82,12 +82,11 @@ func TestNetworkInfoCollector_Constructor(t *testing.T) {
 			errMsg:  "HostSysPath must be an absolute path",
 		},
 		{
-			name: "empty path",
+			name: "empty path (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostSysPath: "",
 			},
-			wantErr: true,
-			errMsg:  "HostSysPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/collectors/tcp.go
+++ b/pkg/performance/collectors/tcp.go
@@ -62,9 +62,9 @@ var tcpStates = map[string]string{
 }
 
 func NewTCPCollector(logger logr.Logger, config performance.CollectionConfig) (*TCPCollector, error) {
-	// Validate paths are absolute
-	if !filepath.IsAbs(config.HostProcPath) {
-		return nil, fmt.Errorf("HostProcPath must be an absolute path, got: %q", config.HostProcPath)
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	capabilities := performance.CollectorCapabilities{

--- a/pkg/performance/collectors/tcp_test.go
+++ b/pkg/performance/collectors/tcp_test.go
@@ -43,7 +43,9 @@ func createTestTCPCollector(t *testing.T, procPath string) *collectors.TCPCollec
 			performance.MetricTypeTCP: true,
 		},
 	}
-	return collectors.NewTCPCollector(logr.Discard(), config)
+	collector, err := collectors.NewTCPCollector(logr.Discard(), config)
+	require.NoError(t, err)
+	return collector
 }
 
 func setupTestFiles(t *testing.T, files map[string]string) string {
@@ -69,6 +71,53 @@ func collectAndValidate(t *testing.T, collector *collectors.TCPCollector) *perfo
 	require.NotNil(t, stats.ConnectionsByState)
 
 	return stats
+}
+
+func TestTCPCollector_Constructor(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  performance.CollectionConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid absolute path",
+			config: performance.CollectionConfig{
+				HostProcPath: "/proc",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid relative path",
+			config: performance.CollectionConfig{
+				HostProcPath: "proc",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+		{
+			name: "empty path",
+			config: performance.CollectionConfig{
+				HostProcPath: "",
+			},
+			wantErr: true,
+			errMsg:  "HostProcPath must be an absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := collectors.NewTCPCollector(logr.Discard(), tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, collector)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, collector)
+			}
+		})
+	}
 }
 
 func TestTCPCollector_BasicFunctionality(t *testing.T) {
@@ -362,7 +411,7 @@ func TestTCPCollector_AllConnectionStates(t *testing.T) {
 
 	// Create one connection for each state
 	i := 0
-	for hexState, _ := range stateMap {
+	for hexState := range stateMap {
 		line := fmt.Sprintf("  %2d: 0100007F:%04X 0100007F:0050 %s 00000000:00000000 00:00000000 00000000  1000        0 %d 1 0000000000000000 20 4 29 10 -1\n",
 			i, 0x1000+i, hexState, 12345+i)
 		tcpContent.WriteString(line)

--- a/pkg/performance/collectors/tcp_test.go
+++ b/pkg/performance/collectors/tcp_test.go
@@ -96,12 +96,11 @@ func TestTCPCollector_Constructor(t *testing.T) {
 			errMsg:  "HostProcPath must be an absolute path",
 		},
 		{
-			name: "empty path",
+			name: "empty path (allowed for defaults)",
 			config: performance.CollectionConfig{
 				HostProcPath: "",
 			},
-			wantErr: true,
-			errMsg:  "HostProcPath must be an absolute path",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/performance/types.go
+++ b/pkg/performance/types.go
@@ -94,7 +94,8 @@ type LoadStats struct {
 	Uptime time.Duration
 }
 
-// MemoryStats represents memory usage information from /proc/meminfo
+// MemoryStats represents runtime memory usage statistics from /proc/meminfo
+// Used by MemoryCollector for operational monitoring and performance analysis
 type MemoryStats struct {
 	// Basic memory stats (all values in kB from /proc/meminfo)
 	MemTotal     uint64 // MemTotal: Total usable RAM
@@ -132,7 +133,10 @@ type MemoryStats struct {
 	// HugePages
 	HugePages_Total uint64 // HugePages_Total: Total number of hugepages
 	HugePages_Free  uint64 // HugePages_Free: Number of free hugepages
+	HugePages_Rsvd  uint64 // HugePages_Rsvd: Number of reserved hugepages
+	HugePages_Surp  uint64 // HugePages_Surp: Number of surplus hugepages
 	HugePagesize    uint64 // Hugepagesize: Default hugepage size (in kB)
+	Hugetlb         uint64 // Hugetlb: Total memory consumed by huge pages of all sizes
 }
 
 // CPUStats represents per-CPU statistics from /proc/stat
@@ -410,7 +414,8 @@ type CPUCore struct {
 	CPUMHz     float64 // Current frequency
 }
 
-// MemoryInfo represents memory hardware configuration
+// MemoryInfo represents memory hardware configuration and NUMA topology
+// Used by MemoryInfoCollector for hardware inventory and capacity planning
 type MemoryInfo struct {
 	// Total memory from /proc/meminfo
 	TotalBytes uint64

--- a/pkg/performance/types.go
+++ b/pkg/performance/types.go
@@ -7,6 +7,8 @@
 package performance
 
 import (
+	"fmt"
+	"path/filepath"
 	"time"
 )
 
@@ -370,6 +372,28 @@ func (c *CollectionConfig) ApplyDefaults() {
 	if c.HostDevPath == "" {
 		c.HostDevPath = defaults.HostDevPath
 	}
+}
+
+// Validate checks that all configured paths are absolute paths.
+// This centralizes path validation logic that was previously duplicated
+// across all collector constructors.
+func (c CollectionConfig) Validate() error {
+	// Validate HostProcPath if configured
+	if c.HostProcPath != "" && !filepath.IsAbs(c.HostProcPath) {
+		return fmt.Errorf("HostProcPath must be an absolute path, got: %q", c.HostProcPath)
+	}
+
+	// Validate HostSysPath if configured
+	if c.HostSysPath != "" && !filepath.IsAbs(c.HostSysPath) {
+		return fmt.Errorf("HostSysPath must be an absolute path, got: %q", c.HostSysPath)
+	}
+
+	// Validate HostDevPath if configured
+	if c.HostDevPath != "" && !filepath.IsAbs(c.HostDevPath) {
+		return fmt.Errorf("HostDevPath must be an absolute path, got: %q", c.HostDevPath)
+	}
+
+	return nil
 }
 
 // CPUInfo represents CPU hardware configuration

--- a/tools/collector-bench/main.go
+++ b/tools/collector-bench/main.go
@@ -61,11 +61,32 @@ func main() {
 	logger := logr.Discard()
 
 	// Create all collectors
+	cpuInfo, err := collectors.NewCPUInfoCollector(logger, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create CPU info collector: %v\n", err)
+		os.Exit(1)
+	}
+	memInfo, err := collectors.NewMemoryInfoCollector(logger, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create memory info collector: %v\n", err)
+		os.Exit(1)
+	}
+	diskInfo, err := collectors.NewDiskInfoCollector(logger, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create disk info collector: %v\n", err)
+		os.Exit(1)
+	}
+	netInfo, err := collectors.NewNetworkInfoCollector(logger, config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create network info collector: %v\n", err)
+		os.Exit(1)
+	}
+
 	collectors := []performance.PointCollector{
-		collectors.NewCPUInfoCollector(logger, config),
-		collectors.NewMemoryInfoCollector(logger, config),
-		collectors.NewDiskInfoCollector(logger, config),
-		collectors.NewNetworkInfoCollector(logger, config),
+		cpuInfo,
+		memInfo,
+		diskInfo,
+		netInfo,
 	}
 
 	// Filter collectors if requested

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,9 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
## Summary
- Centralizes path validation logic into a single `Validate()` method on `CollectionConfig`
- Eliminates code duplication across 9 collectors
- Ensures consistent validation behavior across all collectors

## Changes
1. **Added `Validate()` method to `CollectionConfig`** in `pkg/performance/types.go`
   - Single source of truth for path validation
   - Allows empty paths (which use defaults)
   - Validates non-empty paths are absolute

2. **Updated all collectors** to use centralized validation
   - Replaced individual path checks with `config.Validate()` call
   - Special handling preserved for LoadCollector's additional existence check

3. **Comprehensive test coverage**
   - Added tests for `Validate()` method covering all scenarios
   - Updated collector tests to expect empty paths as valid

## Motivation
Addresses #54 - Multiple collectors were implementing identical path validation logic, violating DRY principles.

## Test Plan
- [x] All existing tests pass
- [x] Added new tests for `Validate()` method
- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)