### PR TITLE
refactor: create global registry for collector factories

### DIFF
--- a/pkg/performance/collector_test.go
+++ b/pkg/performance/collector_test.go
@@ -208,7 +208,7 @@ func TestOnceContinuousCollector(t *testing.T) {
 
 		// Verify channel is closed after one-shot collection
 		select {
-		case data, chOpen = <-ch:
+		case _, chOpen = <-ch:
 			break
 		case <-time.After(500 * time.Millisecond):
 			t.Fatal("Timeout waiting for data point")

--- a/pkg/performance/collectors/cpu.go
+++ b/pkg/performance/collectors/cpu.go
@@ -18,6 +18,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeCPU, performance.PartialNewContinuousPointCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewCPUCollector(logger, config)
+		},
+	))
+}
+
 // Compile-time interface check
 var _ performance.PointCollector = (*CPUCollector)(nil)
 

--- a/pkg/performance/collectors/cpu_info.go
+++ b/pkg/performance/collectors/cpu_info.go
@@ -19,6 +19,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeCPUInfo, performance.PartialNewOnceContinuousCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewCPUInfoCollector(logger, config)
+		},
+	))
+}
+
 // CPUInfoCollector collects CPU hardware configuration from /proc/cpuinfo.
 //
 // IMPORTANT: The /proc/cpuinfo format is NOT standardized across architectures.

--- a/pkg/performance/collectors/disk.go
+++ b/pkg/performance/collectors/disk.go
@@ -19,6 +19,16 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(
+		performance.MetricTypeDisk, performance.PartialNewContinuousPointCollector(
+			func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+				return NewDiskCollector(logger, config)
+			},
+		),
+	)
+}
+
 // Compile-time interface check
 var _ performance.PointCollector = (*DiskCollector)(nil)
 

--- a/pkg/performance/collectors/disk_info.go
+++ b/pkg/performance/collectors/disk_info.go
@@ -18,6 +18,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeDiskInfo, performance.PartialNewOnceContinuousCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewDiskInfoCollector(logger, config)
+		},
+	))
+}
+
 // DiskInfoCollector collects disk hardware configuration from the Linux sysfs filesystem.
 //
 // Data Sources and Methodology:

--- a/pkg/performance/collectors/kernel.go
+++ b/pkg/performance/collectors/kernel.go
@@ -23,6 +23,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeKernel,
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.ContinuousCollector, error) {
+			return NewKernelCollector(logger, config)
+		},
+	)
+}
+
 // Compile-time interface checks
 var (
 	_ performance.PointCollector      = (*KernelCollector)(nil)

--- a/pkg/performance/collectors/load.go
+++ b/pkg/performance/collectors/load.go
@@ -19,6 +19,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeLoad, performance.PartialNewContinuousPointCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewLoadCollector(logger, config)
+		},
+	))
+}
+
 // Compile-time interface check
 var _ performance.PointCollector = (*LoadCollector)(nil)
 

--- a/pkg/performance/collectors/memory.go
+++ b/pkg/performance/collectors/memory.go
@@ -19,6 +19,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeMemory, performance.PartialNewContinuousPointCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewMemoryCollector(logger, config)
+		},
+	))
+}
+
 // Compile-time interface check
 var _ performance.PointCollector = (*MemoryCollector)(nil)
 

--- a/pkg/performance/collectors/memory_info.go
+++ b/pkg/performance/collectors/memory_info.go
@@ -19,6 +19,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeMemoryInfo, performance.PartialNewOnceContinuousCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewMemoryInfoCollector(logger, config)
+		},
+	))
+}
+
 // MemoryInfoCollector collects memory hardware configuration and NUMA topology.
 //
 // Purpose: Hardware inventory and NUMA topology discovery

--- a/pkg/performance/collectors/network_info.go
+++ b/pkg/performance/collectors/network_info.go
@@ -18,6 +18,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeNetworkInfo, performance.PartialNewOnceContinuousCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewNetworkInfoCollector(logger, config)
+		},
+	))
+}
+
 // NetworkInfoCollector collects network interface hardware configuration from the Linux sysfs filesystem.
 //
 // Data Sources and Standardization:

--- a/pkg/performance/collectors/tcp.go
+++ b/pkg/performance/collectors/tcp.go
@@ -19,6 +19,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+func init() {
+	performance.Register(performance.MetricTypeTCP, performance.PartialNewContinuousPointCollector(
+		func(logger logr.Logger, config performance.CollectionConfig) (performance.PointCollector, error) {
+			return NewTCPCollector(logger, config)
+		},
+	))
+}
+
 // Compile-time interface check
 var _ performance.PointCollector = (*TCPCollector)(nil)
 

--- a/pkg/performance/manager.go
+++ b/pkg/performance/manager.go
@@ -17,7 +17,6 @@ import (
 type Manager struct {
 	config      CollectionConfig
 	logger      logr.Logger
-	registry    *CollectorRegistry
 	nodeName    string
 	clusterName string
 }
@@ -65,25 +64,11 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	m := &Manager{
 		config:      config,
 		logger:      opts.Logger.WithName("performance-manager"),
-		registry:    NewCollectorRegistry(opts.Logger),
 		nodeName:    nodeName,
 		clusterName: opts.ClusterName,
 	}
 
 	return m, nil
-}
-
-func (m *Manager) RegisterPointCollector(collector PointCollector) error {
-	return m.registry.RegisterPoint(collector)
-}
-
-func (m *Manager) RegisterContinuousCollector(collector ContinuousCollector) error {
-	return m.registry.RegisterContinuous(collector)
-}
-
-// GetRegistry returns the collector registry for inspection
-func (m *Manager) GetRegistry() *CollectorRegistry {
-	return m.registry
 }
 
 // GetConfig returns the current configuration

--- a/pkg/performance/registry.go
+++ b/pkg/performance/registry.go
@@ -8,100 +8,32 @@ package performance
 
 import (
 	"fmt"
-
-	"github.com/go-logr/logr"
 )
 
-type CollectorRegistry struct {
-	pointCollectors      map[MetricType]PointCollector
-	continuousCollectors map[MetricType]ContinuousCollector
-	logger               logr.Logger
+var registry = make(map[MetricType]NewContinuousCollector)
+
+// Register adds a NewCollector factory to the global registry for metricType.
+// collector is used to create new collector instances with the provided logger and
+// configuration.
+//
+// This function is usually called during package initialization (typically in init() functions)
+// to register collector implementations before they can be instantiated by performance.Manager.
+//
+// It will panic if a collector for the given metricType is already registered
+func Register(metricType MetricType, collector NewContinuousCollector) {
+	_, exists := registry[metricType]
+	if exists {
+		panic(fmt.Sprintf("Collector for %s already registered", metricType))
+	}
+	registry[metricType] = collector
 }
 
-func NewCollectorRegistry(logger logr.Logger) *CollectorRegistry {
-	return &CollectorRegistry{
-		pointCollectors:      make(map[MetricType]PointCollector),
-		continuousCollectors: make(map[MetricType]ContinuousCollector),
-		logger:               logger.WithName("registry"),
+// GetCollector retrieves the collector factory function from the global registry for metricType.
+// The returned factory function can be used to create new collector instances.
+func GetCollector(metricType MetricType) (NewContinuousCollector, error) {
+	collector, exists := registry[metricType]
+	if !exists {
+		return nil, fmt.Errorf("Collector for %s not found", metricType)
 	}
-}
-
-func (r *CollectorRegistry) RegisterPoint(collector PointCollector) error {
-	if collector == nil {
-		return fmt.Errorf("cannot register nil collector")
-	}
-
-	metricType := collector.Type()
-	if _, exists := r.pointCollectors[metricType]; exists {
-		return fmt.Errorf("point collector for metric type %s already registered", metricType)
-	}
-	if _, exists := r.continuousCollectors[metricType]; exists {
-		return fmt.Errorf("continuous collector for metric type %s already registered", metricType)
-	}
-
-	r.pointCollectors[metricType] = collector
-	r.logger.Info("registered point collector", "type", metricType, "name", collector.Name())
-	return nil
-}
-
-func (r *CollectorRegistry) RegisterContinuous(collector ContinuousCollector) error {
-	if collector == nil {
-		return fmt.Errorf("cannot register nil collector")
-	}
-
-	metricType := collector.Type()
-	if _, exists := r.continuousCollectors[metricType]; exists {
-		return fmt.Errorf("continuous collector for metric type %s already registered", metricType)
-	}
-	if _, exists := r.pointCollectors[metricType]; exists {
-		return fmt.Errorf("point collector for metric type %s already registered", metricType)
-	}
-
-	r.continuousCollectors[metricType] = collector
-	r.logger.Info("registered continuous collector", "type", metricType, "name", collector.Name())
-	return nil
-}
-
-func (r *CollectorRegistry) GetPoint(metricType MetricType) PointCollector {
-	return r.pointCollectors[metricType]
-}
-
-func (r *CollectorRegistry) GetContinuous(metricType MetricType) ContinuousCollector {
-	return r.continuousCollectors[metricType]
-}
-
-func (r *CollectorRegistry) GetAllPoint() []PointCollector {
-	collectors := make([]PointCollector, 0, len(r.pointCollectors))
-	for _, collector := range r.pointCollectors {
-		collectors = append(collectors, collector)
-	}
-	return collectors
-}
-
-func (r *CollectorRegistry) GetAllContinuous() []ContinuousCollector {
-	collectors := make([]ContinuousCollector, 0, len(r.continuousCollectors))
-	for _, collector := range r.continuousCollectors {
-		collectors = append(collectors, collector)
-	}
-	return collectors
-}
-
-func (r *CollectorRegistry) GetEnabledPoint(config CollectionConfig) []PointCollector {
-	var enabled []PointCollector
-	for metricType, collector := range r.pointCollectors {
-		if config.EnabledCollectors[metricType] {
-			enabled = append(enabled, collector)
-		}
-	}
-	return enabled
-}
-
-func (r *CollectorRegistry) GetEnabledContinuous(config CollectionConfig) []ContinuousCollector {
-	var enabled []ContinuousCollector
-	for metricType, collector := range r.continuousCollectors {
-		if config.EnabledCollectors[metricType] {
-			enabled = append(enabled, collector)
-		}
-	}
-	return enabled
+	return collector, nil
 }


### PR DESCRIPTION
The registry is responsible for providing factories to create a collector for a metric type. The factory takes in a config which will
eventually be supplied by the Manager which will maintain collector configs.

Each collector registers itself to the registry using init(). Note that only 1 collector can be registered per metric type - it will panic if
multiple collector factories for the same metric type are attempting to register.

The registry also only contains ContinuousCollectors so that the manager has only 1 Collector interface do deal with and orchestrate. New helper methods PartialNewContinuousPointCollector and PartialNewOnceContinuousCollector are added to transform PointCollectors to ContinuousCollectors and add them to the registry.

Also update CLAUDE.md to add new collectors to the registry during collector development and deal with some minor lint errors.

Signed-off-by: Hamzah Qudsi <hamzah@antimetal.com>