### PR TITLE
chore: update execsnoop example license header to PolyForm Shield

### DIFF
--- a/cmd/examples/execsnoop/main.go
+++ b/cmd/examples/execsnoop/main.go
@@ -1,16 +1,8 @@
-// Copyright 2024-2025 Antimetal, Inc.
+// Copyright Antimetal, Inc. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 package main
 


### PR DESCRIPTION
## Summary
- Updated the license header in `cmd/examples/execsnoop/main.go` from Apache License 2.0 to PolyForm Shield 1.0.0
- This aligns with the project's license requirements as enforced by the license header generation tool

## Test plan
- [x] Verified license header matches the expected PolyForm Shield format
- [x] Ran `make gen-license-headers` to confirm no additional changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)