### PR TITLE
refactor: create common kernel version utility package

### DIFF
--- a/pkg/kernel/version.go
+++ b/pkg/kernel/version.go
@@ -1,0 +1,122 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+// Package kernel provides utilities for kernel version detection and comparison
+package kernel
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Version represents a parsed kernel version
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+	Raw   string // Original version string
+}
+
+// GetCurrentVersion returns the current kernel version
+func GetCurrentVersion() (*Version, error) {
+	// Try to read from /proc/version
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /proc/version: %w", err)
+	}
+
+	// Parse "Linux version X.Y.Z"
+	parts := strings.Fields(string(data))
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("unexpected /proc/version format: %s", string(data))
+	}
+
+	return ParseVersion(parts[2])
+}
+
+// ParseVersion parses a kernel version string (e.g., "5.15.0-generic" or "5.15.0")
+func ParseVersion(version string) (*Version, error) {
+	v := &Version{Raw: version}
+
+	// Remove any suffix (e.g., "-generic")
+	if idx := strings.Index(version, "-"); idx != -1 {
+		version = version[:idx]
+	}
+
+	// Parse X.Y.Z format
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid kernel version format: %s", version)
+	}
+
+	// Parse major version
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid major version: %s", parts[0])
+	}
+	v.Major = major
+
+	// Parse minor version
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid minor version: %s", parts[1])
+	}
+	v.Minor = minor
+
+	// Parse patch version if present
+	if len(parts) >= 3 {
+		patch, err := strconv.Atoi(parts[2])
+		if err != nil {
+			// Patch might have additional info, just use 0
+			v.Patch = 0
+		} else {
+			v.Patch = patch
+		}
+	}
+
+	return v, nil
+}
+
+// IsAtLeast returns true if the current version is >= the specified version
+func (v *Version) IsAtLeast(major, minor int) bool {
+	if v.Major > major {
+		return true
+	}
+	if v.Major == major && v.Minor >= minor {
+		return true
+	}
+	return false
+}
+
+// String returns the version as a string
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Compare returns -1 if v < other, 0 if v == other, 1 if v > other
+func (v *Version) Compare(other *Version) int {
+	if v.Major != other.Major {
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/pkg/kernel/version_test.go
+++ b/pkg/kernel/version_test.go
@@ -1,0 +1,259 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package kernel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Version
+		wantErr bool
+	}{
+		{
+			name:  "standard version",
+			input: "5.15.0",
+			want: &Version{
+				Major: 5,
+				Minor: 15,
+				Patch: 0,
+				Raw:   "5.15.0",
+			},
+		},
+		{
+			name:  "version with suffix",
+			input: "5.15.0-generic",
+			want: &Version{
+				Major: 5,
+				Minor: 15,
+				Patch: 0,
+				Raw:   "5.15.0-generic",
+			},
+		},
+		{
+			name:  "version without patch",
+			input: "5.15",
+			want: &Version{
+				Major: 5,
+				Minor: 15,
+				Patch: 0,
+				Raw:   "5.15",
+			},
+		},
+		{
+			name:  "older kernel version",
+			input: "4.18.0-348.el8.x86_64",
+			want: &Version{
+				Major: 4,
+				Minor: 18,
+				Patch: 0,
+				Raw:   "4.18.0-348.el8.x86_64",
+			},
+		},
+		{
+			name:  "kernel 6.x",
+			input: "6.2.0-26-generic",
+			want: &Version{
+				Major: 6,
+				Minor: 2,
+				Patch: 0,
+				Raw:   "6.2.0-26-generic",
+			},
+		},
+		{
+			name:  "patch with extra info",
+			input: "5.10.0rc1",
+			want: &Version{
+				Major: 5,
+				Minor: 10,
+				Patch: 0, // Can't parse "0rc1" as int
+				Raw:   "5.10.0rc1",
+			},
+		},
+		{
+			name:    "invalid format - single number",
+			input:   "5",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - non-numeric major",
+			input:   "v5.15.0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - non-numeric minor",
+			input:   "5.x.0",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVersion(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVersion_IsAtLeast(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     *Version
+		major       int
+		minor       int
+		want        bool
+	}{
+		{
+			name:    "exact match",
+			version: &Version{Major: 5, Minor: 8},
+			major:   5,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "newer major version",
+			version: &Version{Major: 6, Minor: 0},
+			major:   5,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "newer minor version",
+			version: &Version{Major: 5, Minor: 10},
+			major:   5,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "older major version",
+			version: &Version{Major: 4, Minor: 18},
+			major:   5,
+			minor:   8,
+			want:    false,
+		},
+		{
+			name:    "same major, older minor",
+			version: &Version{Major: 5, Minor: 4},
+			major:   5,
+			minor:   8,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.version.IsAtLeast(tt.major, tt.minor)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVersion_Compare(t *testing.T) {
+	tests := []struct {
+		name  string
+		v1    *Version
+		v2    *Version
+		want  int
+	}{
+		{
+			name: "equal versions",
+			v1:   &Version{Major: 5, Minor: 8, Patch: 0},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 0},
+			want: 0,
+		},
+		{
+			name: "v1 newer major",
+			v1:   &Version{Major: 6, Minor: 0, Patch: 0},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 0},
+			want: 1,
+		},
+		{
+			name: "v1 older major",
+			v1:   &Version{Major: 4, Minor: 18, Patch: 0},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 0},
+			want: -1,
+		},
+		{
+			name: "same major, v1 newer minor",
+			v1:   &Version{Major: 5, Minor: 10, Patch: 0},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 0},
+			want: 1,
+		},
+		{
+			name: "same major, v1 older minor",
+			v1:   &Version{Major: 5, Minor: 4, Patch: 0},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 0},
+			want: -1,
+		},
+		{
+			name: "same major/minor, v1 newer patch",
+			v1:   &Version{Major: 5, Minor: 8, Patch: 10},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 5},
+			want: 1,
+		},
+		{
+			name: "same major/minor, v1 older patch",
+			v1:   &Version{Major: 5, Minor: 8, Patch: 3},
+			v2:   &Version{Major: 5, Minor: 8, Patch: 5},
+			want: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v1.Compare(tt.v2)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		version *Version
+		want    string
+	}{
+		{
+			name:    "standard version",
+			version: &Version{Major: 5, Minor: 15, Patch: 0},
+			want:    "5.15.0",
+		},
+		{
+			name:    "single digit versions",
+			version: &Version{Major: 4, Minor: 4, Patch: 0},
+			want:    "4.4.0",
+		},
+		{
+			name:    "with patch",
+			version: &Version{Major: 5, Minor: 10, Patch: 123},
+			want:    "5.10.123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.version.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extract kernel version parsing logic into a dedicated `pkg/kernel` package
- Eliminate duplicate kernel version parsing code across the codebase
- Add comprehensive unit tests for kernel version functionality

## Changes
- Created `pkg/kernel/version.go` with kernel version detection and comparison utilities
- Added thorough unit tests in `pkg/kernel/version_test.go`
- Updated `pkg/ebpf/core` to use the common kernel utilities
- Removed duplicate `getKernelVersion()` and `parseKernelVersion()` functions

## Motivation
During the review of PR #85 (capabilities system), it was noted that we were implementing kernel version parsing in multiple places. This PR creates a single, well-tested location for kernel version utilities that can be reused throughout the codebase.

## Test Plan
- [x] Unit tests pass for the new kernel package
- [x] eBPF core tests continue to pass with the refactored code
- [ ] Manual testing on different kernel versions

🤖 Generated with [Claude Code](https://claude.ai/code)