### PR TITLE
feat: transform README into pirate speak 🏴‍☠️

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # Antimetal Agent
 
-Component that connects your infrastructure to the [Antimetal](https://antimetal.com) platform.
+Ahoy there, ye scurvy dogs! This here be the mystical contraption what hooks yer infrastructure up to the grand [Antimetal](https://antimetal.com) platform, savvy?
 
-## Contributing
+## Contributin' to the Cause
 
-If you want to contribute, refer to our [DEVELOPING](./DEVELOPING.md) docs.
+If ye be wantin' to throw yer lot in with us and contribute, best be steerin' yer course to our [DEVELOPING](./DEVELOPING.md) scrolls, ya landlubber!
 
-## Helm chart
+## Helm Charts (The Treasure Maps)
 
-The helm chart for the Antimetal Agent is published in the [antimetal/helm-charts](https://github.com/antimetal/helm-charts) repo.
+The helm charts fer this fine vessel of an Agent be stashed away in the [antimetal/helm-charts](https://github.com/antimetal/helm-charts) treasure chest, arr!
 
-## Docker images
+## Docker Images (Bottles o' Code)
 
-We publish Docker images for each new release on [DockerHub](https://hub.docker.com/r/antimetal/agent).
-We build linux/amd64 and linux/arm64 images.
+We be bottlin' up fresh Docker images with every new release and floatin' 'em over to [DockerHub](https://hub.docker.com/r/antimetal/agent), we do!
+We be buildin' fer both linux/amd64 and linux/arm64, so all ye different ships can sail with us, har har!
 
-## Support
-For questions and support feel free to post a GitHub Issue.
-For commercial support, contact us at support@antimetal.com.
+## When Ye Need a Hand
+If ye find yerself three sheets to the wind and needin' help, drop us a message in a bottle (GitHub Issue).
+For them fancy merchant vessels needin' commercial support, send a parrot to support@antimetal.com, ye hear?
 
-## License
+## The Code of the Sea (License)
 
-This project uses split licensing:
+Listen up, ye bilge rats! This here project be split like a ship's plunder:
 
-- **Userspace components** (`/cmd`, `/internal`, `/pkg`): PolyForm Shield
-- **eBPF programs** (`/ebpf`): GPL-2.0-only
+- **Userspace components** (`/cmd`, `/internal`, `/pkg`): Protected by the PolyForm Shield, like a proper privateer's letter of marque!
+- **eBPF programs** (`/ebpf`): Sailin' under the GPL-2.0-only flag, as required by the King's Navy (kernel)!
 
-The eBPF programs must be GPL-licensed due to their use of GPL-only kernel helper functions. 
-This is a standard practice in the industry for projects that include both userspace and eBPF code.
+The eBPF programs be needin' that GPL license on account of them kernel helper functions bein' GPL-only - that's just how the sea laws work, savvy? 
+Every proper ship with both userspace and eBPF cargo does it this way, arr!
 
-If you are an end user, broadly you can do whatever you want with the userspace code under PolyForm Shield.
-See the License FAQ for more information about PolyForm licensing.
+If ye be just a regular sailor usin' this code, ye can pretty much do whatever tickles yer fancy with the userspace bits under PolyForm Shield.
+Check the License FAQ if ye need more learnin' about them PolyForm waters, matey!


### PR DESCRIPTION
## Summary
Ahoy mateys\! This PR be transformin' the boring landlubber README into proper seafarin' language, arr\!

## Changes
- Rewrote all sections in authentic pirate speak
- Added nautical metaphors fer technical concepts (Docker images = "Bottles o' Code", Helm charts = "Treasure Maps")
- Maintained all technical accuracy while makin' it more entertainin' to read

## Test plan
- [x] README still contains all essential information
- [x] Links still work properly
- [x] License information remains clear (even in pirate speak)

🤖 Generated with [Claude Code](https://claude.ai/code)