### PR TITLE
feat(resource): support disk persistence for badger KV store

### DIFF
--- a/config/agent/agent.yaml
+++ b/config/agent/agent.yaml
@@ -50,6 +50,9 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # 65532 is the same UID as the one set in the docker image
+        fsGroup: 65532
+        runAsUser: 65532
         runAsNonRoot: true
       containers:
       - name: agent
@@ -79,6 +82,8 @@ spec:
         - name: HOST_DEV
           value: /host/dev
         volumeMounts:
+        - name: data
+          mountPath: /var/lib/antimetal
         - name: proc
           mountPath: /host/proc
           readOnly: true
@@ -116,6 +121,8 @@ spec:
       terminationGracePeriodSeconds: 10
       automountServiceAccountToken: true
       volumes:
+      - name: data
+        emptyDir: {}
       - name: proc
         hostPath:
           path: /proc

--- a/internal/kubernetes/agent/controller.go
+++ b/internal/kubernetes/agent/controller.go
@@ -209,7 +209,7 @@ func (c *controller) indexObjects(ctx context.Context) {
 	switch ev.typ {
 	case EventAdd:
 		c.logger.V(1).Info("adding object to index", "event", eventStr(ev.typ), "object", ev.obj)
-		err = c.indexer.Add(ctx, ev.obj)
+		err = c.indexer.Update(ctx, ev.obj)
 	case EventUpdate:
 		c.logger.V(1).Info("update object in index", "event", eventStr(ev.typ), "object", ev.obj)
 		err = c.indexer.Update(ctx, ev.obj)

--- a/internal/kubernetes/agent/indexer.go
+++ b/internal/kubernetes/agent/indexer.go
@@ -51,7 +51,7 @@ func (i *indexer) LoadClusterInfo(ctx context.Context, major string, minor strin
 	}
 	i.clusterName = clusterName
 
-	return i.store.AddResource(&resourcev1.Resource{
+	return i.store.UpdateResource(&resourcev1.Resource{
 		Type: &resourcev1.TypeDescriptor{
 			Kind: kindResource,
 			Type: string(cluster.ProtoReflect().Descriptor().FullName()),
@@ -64,20 +64,6 @@ func (i *indexer) LoadClusterInfo(ctx context.Context, major string, minor strin
 		},
 		Spec: clusterAny,
 	})
-}
-
-func (i *indexer) Add(ctx context.Context, obj object) error {
-	rsrc, rels, err := i.generate(obj)
-	if err != nil {
-		return fmt.Errorf("failed to generate resource and relationships: %w", err)
-	}
-	if err := i.store.AddResource(rsrc); err != nil {
-		return fmt.Errorf("failed to add resource to inventory: %w", err)
-	}
-	if err := i.store.AddRelationships(rels...); err != nil {
-		return fmt.Errorf("failed to add relationships for resource to inventory: %w", err)
-	}
-	return nil
 }
 
 func (i *indexer) Update(ctx context.Context, obj object) error {

--- a/pkg/resource/store/store.go
+++ b/pkg/resource/store/store.go
@@ -70,8 +70,14 @@ type store struct {
 }
 
 // New creates a new Store.
-func New() (*store, error) {
-	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true))
+func New(dataDir string) (*store, error) {
+	db, err := badger.Open(
+		badger.DefaultOptions(dataDir).
+			WithInMemory(dataDir == "").
+			WithNumMemtables(3).
+			WithBlockCacheSize(128 << 20).
+			WithIndexCacheSize(64 << 20),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/store/store_test.go
+++ b/pkg/resource/store/store_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestStore_AddResource(t *testing.T) {
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestStore_AddResource(t *testing.T) {
 }
 
 func TestStore_UpdateResourceNewResource(t *testing.T) {
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestStore_UpdateResourceNewResource(t *testing.T) {
 }
 
 func TestStore_UpdateResource(t *testing.T) {
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestStore_GetRelationships(t *testing.T) {
 		expectedNumResult int
 	}
 
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestStore_GetRelationships(t *testing.T) {
 }
 
 func TestStore_DeleteResource_CascadeDelete(t *testing.T) {
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestStore_DeleteResource_CascadeDelete(t *testing.T) {
 }
 
 func TestStore_DeleteResource_NoRelationships(t *testing.T) {
-	inv, err := New()
+	inv, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestStore_DeleteResource_NoRelationships(t *testing.T) {
 }
 
 func TestStore_Subscribe(t *testing.T) {
-	s, err := New()
+	s, err := New("")
 	if err != nil {
 		t.Fatalf("failed to create inventory: %v", err)
 	}


### PR DESCRIPTION
Closes #90

the Badger KV store that underlies the resource store can now be configured to persist to disk.

We also tune the Badger options for the following:
- Lower number of Memtables from 5 -> 3
- Lower block cache size from 256Mb -> 128Mb
- Limit Index cache to 64Mb

These options are to try to bound the memory usage for Badger to ~380Mb:
```
(memtable size * num memtables) + block cache size + index cache size => (64Mb * 3) + 128Mb + 64Mb
```

Future optimizations could be done based on runtime performance.

With resource store disk persistence, the resource store objects can persist across agent restarts. To prevent potential duplicates, we always run an upsert when indexing k8s objects to the resource store. If the resource already exists, then they will be replaced upon agent startup, otherwise it creates the new resource object.