### PR TITLE
chore(ci): Add Checks for lint, license-check, gen-check, and build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
-name: Integration Tests
+name: Build & Test
 
-# This workflow runs integration tests across multiple environments to ensure
+# This workflow runs CI checks & integration tests across multiple environments to ensure
 # compatibility with different Linux kernel versions and system configurations.
 
 on:
@@ -17,6 +17,114 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Cache apt packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-lint-${{ hashFiles('.github/workflows/build_and_test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-lint-
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
+
+    - name: Run linting
+      run: make lint
+
+  license-check:
+    name: License Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Run license check
+      run: make license-check
+
+  gen-check:
+    name: Generation Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Cache apt packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-gen-check-${{ hashFiles('.github/workflows/build_and_test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-gen-check-
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
+
+    - name: Check generated files are up to date
+      run: make gen-check
+
+  build-agent:
+    name: Build Agent Binary - ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Cache apt packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-${{ matrix.arch }}-apt-build-agent-${{ hashFiles('.github/workflows/build_and_test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.arch }}-apt-build-agent-
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
+
+    - name: Build agent binary
+      run: make build
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -34,9 +142,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/integration-tests.yml') }}
+        key: ${{ runner.os }}-apt-unit-tests-${{ hashFiles('.github/workflows/build_and_test.yml') }}
         restore-keys: |
-          ${{ runner.os }}-apt-
+          ${{ runner.os }}-apt-unit-tests-
     
     - name: Install build dependencies
       run: |
@@ -111,9 +219,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/integration-tests.yml') }}
+        key: ${{ runner.os }}-apt-build-artifacts-${{ hashFiles('.github/workflows/build_and_test.yml') }}
         restore-keys: |
-          ${{ runner.os }}-apt-
+          ${{ runner.os }}-apt-build-artifacts-
     
     - name: Install build dependencies
       run: |
@@ -183,7 +291,7 @@ jobs:
           cd /host
           chmod +x .github/workflows/scripts/run-lvh-tests.sh
           GO_VERSION=1.24.0 KERNEL_VERSION="${{ matrix.kernel }}" .github/workflows/scripts/run-lvh-tests.sh
-    
+
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4
@@ -200,19 +308,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests-vm]
     if: always()
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Download all test results
       uses: actions/download-artifact@v4
       with:
         path: test-results/
-    
+
     - name: List downloaded artifacts
       run: |
         echo "Downloaded artifacts:"
         find test-results -type f -name "*.txt" -o -name "*.log" | sort
-    
+
     - name: Generate summary
       run: .github/workflows/scripts/generate-test-summary.sh test-results

--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,11 @@ test-integration: generate manifests build-ebpf ## Run integration tests.
 
 .PHONY: lint
 lint: golangci-lint generate ## Run golangci-lint linter & yamllint.
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --timeout 10m
 
 .PHONY: lint-fix
 lint-fix: golangci-lint generate ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) run --fix --timeout 10m
 
 ##@ eBPF
 


### PR DESCRIPTION
Expand the integration tests GH Actions workflow (now renamed to Build & Test) to add additional checks to get a full CI coverage suite.

There's def some optimizations that could be made like generating artifacts once to be use throughout all jobs but that can be cleaned up later.