### PR TITLE
fix(perf): clear lastError on Stop() to reset collector status

### DIFF
--- a/pkg/performance/collectors/kernel.go
+++ b/pkg/performance/collectors/kernel.go
@@ -379,6 +379,7 @@ func (c *KernelCollector) Stop() error {
 	}
 
 	c.isRunning = false
+	c.lastError = nil // Clear error on stop to reset to disabled status
 
 	return nil
 }


### PR DESCRIPTION
The kernel collector's Stop() method now clears lastError to ensure the status properly transitions back to 'disabled' after stopping, rather than remaining 'failed' if there were previous errors.

This fixes the CI test failure in TestKernelCollector_ContinuousCollection which expected disabled status after stopping the collector.