### PR TITLE
test: add kernel version check to execsnoop integration test

### DIFF
--- a/pkg/performance/collectors/execsnoop_integration_test.go
+++ b/pkg/performance/collectors/execsnoop_integration_test.go
@@ -10,11 +10,11 @@ package collectors_test
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"testing"
 	"time"
 
+	"github.com/antimetal/agent/pkg/kernel"
 	"github.com/antimetal/agent/pkg/performance"
 	"github.com/antimetal/agent/pkg/performance/collectors"
 	"github.com/cilium/ebpf/rlimit"
@@ -24,8 +24,16 @@ import (
 )
 
 func TestExecSnoopCollector_Integration(t *testing.T) {
+	// Check kernel version first - ExecSnoop requires 5.8+ for ring buffer support
+	currentKernel, err := kernel.GetCurrentVersion()
+	require.NoError(t, err, "Failed to get current kernel version")
+	
+	if !currentKernel.IsAtLeast(5, 8) {
+		t.Skipf("ExecSnoop collector requires kernel 5.8+ for ring buffer support, current kernel is %s", currentKernel.String())
+	}
+
 	// Remove memory limit for eBPF
-	err := rlimit.RemoveMemlock()
+	err = rlimit.RemoveMemlock()
 	require.NoError(t, err, "Failed to remove memlock limit - integration tests require proper permissions")
 
 	logger := logr.Discard()
@@ -131,7 +139,7 @@ func TestExecSnoopCollector_Integration(t *testing.T) {
 		err = collector.Stop()
 		require.NoError(t, err)
 
-		// Verify collector is stopped
-		assert.Equal(t, performance.CollectorStatusStopped, collector.Status())
+		// Verify collector is disabled after stop
+		assert.Equal(t, performance.CollectorStatusDisabled, collector.Status())
 	})
 }


### PR DESCRIPTION
## Summary
- Add kernel version validation to ExecSnoop integration test
- Skip test gracefully on kernels < 5.8 with descriptive message
- Fix test status assertion to use CollectorStatusDisabled

## Test plan
- [x] Test passes on kernel 5.8+
- [x] Test skips properly on kernel < 5.8

🤖 Generated with [Claude Code](https://claude.ai/code)