### PR TITLE
chore: remove proto from generate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ install-hooks: ## Install shared git hooks for development workflow.
 
 .PHONY: generate
 generate: ## Generate all artifacts
-generate: manifests generate-ebpf-types generate-ebpf-bindings proto
+generate: manifests generate-ebpf-types generate-ebpf-bindings
 
 .PHONY: ebpf-typegen
 ebpf-typegen: ## Build the ebpf-typegen tool


### PR DESCRIPTION
buf generate easily runs into rate limits for unathenticated requests. Remove it from generate for now since you need to call this only when you want to update the public apis protos.