### PR TITLE
fix(ci): remove pb.go files from buf cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,12 +43,10 @@ jobs:
           ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}-
           ${{ runner.os }}-tools-
 
-    - name: Cache buf modules and generated files
+    - name: Cache buf modules
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/buf
-          pkg/api/**/*.pb.go
+        path: ~/.cache/buf
         key: ${{ runner.os }}-buf-${{ hashFiles('buf.gen.yaml') }}
         restore-keys: |
           ${{ runner.os }}-buf-


### PR DESCRIPTION
pb.go files are generated using `make proto` and are checked into the repo so no need to cache them. It can also cause problems when the protos are updated resulting in flakiness in CI.