### PR TITLE
refactor(performance): remove Stop() from ContinuousCollector interface

### DIFF
--- a/cmd/examples/execsnoop/main.go
+++ b/cmd/examples/execsnoop/main.go
@@ -59,10 +59,12 @@ func main() {
 	for {
 		select {
 		case <-ctx.Done():
-			goto cleanup
+			fmt.Printf("\nProcessed %d events\n", eventCount)
+			return
 		case event, ok := <-eventChan:
 			if !ok {
-				goto cleanup
+				fmt.Printf("\nProcessed %d events\n", eventCount)
+				return
 			}
 			if execEvent, ok := event.(*collectors.ExecEvent); ok {
 				eventCount++
@@ -76,12 +78,4 @@ func main() {
 			}
 		}
 	}
-
-cleanup:
-	err = collector.Stop()
-	if err != nil {
-		log.Printf("Error stopping collector: %v", err)
-	}
-
-	fmt.Printf("\nProcessed %d events\n", eventCount)
 }

--- a/internal/hardware/manager.go
+++ b/internal/hardware/manager.go
@@ -221,12 +221,6 @@ func (m *Manager) collectHardwareSnapshot(ctx context.Context) (*performance.Sna
 			Duration: time.Since(collectorStartTime),
 			Data:     data,
 		}
-
-		// Stop the collector to clean up resources
-		if err := collector.Stop(); err != nil {
-			m.logger.V(1).Info("Error stopping collector",
-				"metric_type", metricType, "error", err)
-		}
 	}
 
 	snapshot.CollectorRun.Duration = time.Since(startTime)

--- a/pkg/kernel/kernel_compat_integration_test.go
+++ b/pkg/kernel/kernel_compat_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/antimetal/agent/pkg/performance"
 	_ "github.com/antimetal/agent/pkg/performance/collectors" // Import to register collectors
 	"github.com/go-logr/logr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/kernel/kernel_compat_integration_test.go
+++ b/pkg/kernel/kernel_compat_integration_test.go
@@ -205,9 +205,8 @@ func TestCollectorCompatibility(t *testing.T) {
 				t.Errorf("%s: Timeout waiting for data", tc.name)
 			}
 
-			// Stop the collector
-			err = collector.Stop()
-			assert.NoError(t, err, "Failed to stop %s", tc.name)
+			// Context cancellation will trigger cleanup
+			cancel()
 		})
 	}
 }

--- a/pkg/performance/collectors/execsnoop_test.go
+++ b/pkg/performance/collectors/execsnoop_test.go
@@ -301,13 +301,10 @@ func TestExecSnoopCollector_StartStop(t *testing.T) {
 	_, err = collector.Start(ctx)
 	assert.Error(t, err, "Start should fail with missing BPF object or unsupported platform")
 
-	// Stop should work even if start failed
-	err = collector.Stop()
-	assert.NoError(t, err)
-
-	// Multiple stops should be safe
-	err = collector.Stop()
-	assert.NoError(t, err)
+	// Context cancellation should clean up gracefully even if start failed
+	cancel()
+	// Give time for any cleanup
+	time.Sleep(50 * time.Millisecond)
 }
 
 func TestExecSnoopCollector_DoubleStart(t *testing.T) {

--- a/pkg/performance/collectors/kernel_test.go
+++ b/pkg/performance/collectors/kernel_test.go
@@ -238,16 +238,13 @@ func TestKernelCollector_ContinuousCollection(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already running")
 
-	// Test Stop
-	err = collector.Stop()
-	require.NoError(t, err)
+	// Test cleanup via context cancellation
+	cancel()
+	// Give the collector time to clean up
+	time.Sleep(50 * time.Millisecond)
 
-	// Test Status after stopping
+	// Test Status after context cancellation
 	assert.Equal(t, performance.CollectorStatusDisabled, collector.Status())
-
-	// Test double stop should be ok
-	err = collector.Stop()
-	assert.NoError(t, err)
 }
 
 func TestKernelCollector_ParseMessageContent(t *testing.T) {

--- a/pkg/performance/collectors/process_test.go
+++ b/pkg/performance/collectors/process_test.go
@@ -103,9 +103,10 @@ func TestProcessCollector(t *testing.T) {
 	// Test that we respect the top N limit
 	assert.LessOrEqual(t, len(secondCollection), 20)
 
-	// Test Stop
-	err = collector.Stop()
-	require.NoError(t, err)
+	// Test cleanup via context cancellation
+	cancel()
+	// Give the collector time to clean up
+	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, performance.CollectorStatusDisabled, collector.Status())
 }
 


### PR DESCRIPTION
## Summary

This PR refactors the ContinuousCollector interface to remove the Stop() method entirely, relying solely on context cancellation for lifecycle management. This simplification eliminates race conditions, reduces code complexity, and follows Go best practices.

## Changes

### Core Interface
- Removed Stop() error from the ContinuousCollector interface
- Updated interface documentation to clarify context-based cleanup

### Collector Implementations
- **ExecSnoopCollector**: Simplified to single goroutine with defer-based cleanup
- **ProcessCollector**: Removed Stop(), cleanup via deferred function in runCollection
- **KernelCollector**: Updated continuousCollectionLoop with deferred cleanup
- **Wrapper collectors**: Updated ContinuousPointCollector and OnceContinuousCollector

### Test Updates
- Replaced all Stop() calls with context cancellation
- Added appropriate timeouts for cleanup verification
- Updated integration tests to use context patterns

### Consumer Code
- Hardware Manager: Removed unnecessary Stop() calls for OnceContinuousCollector
- ExecSnoop example: Updated to rely on context cancellation

## Benefits

✅ **Simpler Interface**: One cancellation mechanism instead of two (context + Stop)
✅ **No Race Conditions**: Eliminates races between Stop() and context cancellation  
✅ **Idiomatic Go**: Follows standard Go patterns for context-based lifecycle management
✅ **Less Code**: Removed ~109 lines while maintaining all functionality
✅ **Maintainability**: Fewer edge cases (no double stop scenarios)

## Testing

- ✅ All unit tests pass
- ✅ Integration tests verified
- ✅ No goroutine leaks
- ✅ Proper cleanup on context cancellation confirmed

## Breaking Changes

This is a breaking change for any external code using the ContinuousCollector interface. Consumers need to:
1. Remove any Stop() calls
2. Use context cancellation for cleanup
3. Allow time for cleanup to complete if synchronous shutdown is needed