### PR TITLE
chore(license): move license header into a separate txt file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,7 @@ Always run `make generate` after:
 
 #### License Headers
 - **ALWAYS** run `make gen-license-headers` before committing
-- All Go files must have the PolyForm Shield license header
-- Uses `tools/license_check/license_check.py` for enforcement
+- **ALL** .go files must have the PolyForm Shield license header located in @tools/license_check/license_header.txt
 
 #### Testing Philosophy
 - Use standard Go testing framework

--- a/tools/license_check/license_check.py
+++ b/tools/license_check/license_check.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+from pathlib import Path
 
 parser = argparse.ArgumentParser(description="Check that license header is included in Go files.")
 parser.add_argument(
@@ -17,13 +18,8 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-# Define the header you want to check for and insert
-header = """// Copyright Antimetal, Inc. All rights reserved.
-//
-// Use of this source code is governed by a source available license that can be found in the
-// LICENSE file or at:
-// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
-"""
+with open(Path(__file__).with_name("license_header.txt")) as f:
+    header = f.read().strip()
 
 exclude_dirs = (
   './.git',

--- a/tools/license_check/license_header.txt
+++ b/tools/license_check/license_header.txt
@@ -1,0 +1,5 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt


### PR DESCRIPTION
Try to make it easier for the LLM to properly add license headers.