### PR TITLE
Support TTL in config agent

### DIFF
--- a/internal/config/ams.go
+++ b/internal/config/ams.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -28,10 +29,14 @@ import (
 )
 
 const (
-	headerAuthorize         = "authorization"
-	defaultMaxStreamAge     = 10 * time.Minute
-	streamRestartBackoffMax = 30 * time.Second
+	headerAuthorize     = "authorization"
+	defaultMaxStreamAge = 10 * time.Minute
 )
+
+type ttlIdxNode struct {
+	cacheKey string
+	ttl      time.Time
+}
 
 type AMSLoader struct {
 	apiKey       string
@@ -45,6 +50,8 @@ type AMSLoader struct {
 	subs       subscriptions
 	cache      map[string]Instance
 	cacheMu    sync.RWMutex
+	ttlIdx     []*ttlIdxNode
+	ttlIdxMu   sync.Mutex
 	cancel     context.CancelFunc
 	lastSeqNum string
 	closeOnce  sync.Once
@@ -108,6 +115,12 @@ func NewAMSLoader(conn *grpc.ClientConn, opts ...AMSLoaderOpts) (*AMSLoader, err
 	go func() {
 		defer l.wg.Done()
 		l.manageStream(ctx)
+	}()
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.manageTTLPruning(ctx)
 	}()
 
 	return l, nil
@@ -186,6 +199,30 @@ func (l *AMSLoader) manageStream(ctx context.Context) {
 			return
 		default:
 			l.runStream(ctx)
+		}
+	}
+}
+
+func (l *AMSLoader) manageTTLPruning(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			prunedConfigs := l.pruneTTLIdx()
+			if len(prunedConfigs) == 0 {
+				continue
+			}
+
+			l.cacheMu.Lock()
+			for _, cacheKey := range prunedConfigs {
+				if instance, exists := l.cache[cacheKey]; exists {
+					instance.Expired = true
+					delete(l.cache, cacheKey)
+					l.subs.send(instance)
+				}
+			}
+			l.cacheMu.Unlock()
 		}
 	}
 }
@@ -348,6 +385,7 @@ func (l *AMSLoader) processConfig(obj *typesv1.Object) (Instance, error) {
 	cacheKey := l.getCacheKey(instance.TypeUrl, instance.Name)
 	l.cacheMu.Lock()
 	defer l.cacheMu.Unlock()
+
 	prevInstance := l.cache[cacheKey]
 
 	compVer, err := CompareVersions(instance.Version, prevInstance.Version)
@@ -361,15 +399,122 @@ func (l *AMSLoader) processConfig(obj *typesv1.Object) (Instance, error) {
 			instance.Version, prevInstance.Version,
 		)
 	}
-	if parseErr == nil || prevInstance.Object == nil {
-		l.cache[cacheKey] = instance
+
+	// Update the cache only if it's a new config or the new config is valid
+	if parseErr != nil && prevInstance.Object != nil {
+		return instance, parseErr
 	}
+
+	l.cache[cacheKey] = instance
+
+	var ttlDuration time.Duration
+	if obj.GetTtl() != nil {
+		ttlDuration = obj.GetTtl().AsDuration()
+	}
+
+	// Don't add to ttlIdx if new config object ttl is not set
+	if ttlDuration <= 0 {
+		if prevInstance.Object != nil {
+			l.removeCfgFromTTLIdx(cacheKey)
+		}
+		return instance, parseErr
+	}
+
+	expiryTime := time.Now().Add(ttlDuration)
+
+	if prevInstance.Object == nil {
+		l.addCfgToTTLIdx(cacheKey, expiryTime)
+		return instance, parseErr
+	}
+
+	l.updateCfgInTTLIdx(cacheKey, expiryTime)
 
 	return instance, parseErr
 }
 
 func (l *AMSLoader) getCacheKey(configType, name string) string {
 	return configType + ":" + name
+}
+
+func (l *AMSLoader) addCfgToTTLIdx(name string, ttl time.Time) {
+	l.ttlIdxMu.Lock()
+	defer l.ttlIdxMu.Unlock()
+
+	newNode := &ttlIdxNode{
+		cacheKey: name,
+		ttl:      ttl,
+	}
+
+	idx, _ := slices.BinarySearchFunc(l.ttlIdx, newNode, func(a, b *ttlIdxNode) int {
+		if a.ttl.Before(b.ttl) {
+			return -1
+		}
+		if a.ttl.After(b.ttl) {
+			return 1
+		}
+		return 0
+	})
+
+	l.ttlIdx = slices.Insert(l.ttlIdx, idx, newNode)
+}
+
+func (l *AMSLoader) updateCfgInTTLIdx(name string, ttl time.Time) {
+	l.ttlIdxMu.Lock()
+	defer l.ttlIdxMu.Unlock()
+
+	for _, node := range l.ttlIdx {
+		if node.cacheKey == name {
+			node.ttl = ttl
+			break
+		}
+	}
+
+	slices.SortFunc(l.ttlIdx, func(a, b *ttlIdxNode) int {
+		if a.ttl.Before(b.ttl) {
+			return -1
+		}
+		if a.ttl.After(b.ttl) {
+			return 1
+		}
+		return 0
+	})
+}
+
+func (l *AMSLoader) removeCfgFromTTLIdx(name string) {
+	l.ttlIdxMu.Lock()
+	defer l.ttlIdxMu.Unlock()
+
+	for i, node := range l.ttlIdx {
+		if node.cacheKey == name {
+			l.ttlIdx = slices.Delete(l.ttlIdx, i, i+1)
+			return
+		}
+	}
+}
+
+func (l *AMSLoader) pruneTTLIdx() []string {
+	l.ttlIdxMu.Lock()
+	defer l.ttlIdxMu.Unlock()
+
+	now := time.Now()
+	var prunedConfigs []string
+	var pruneCount int
+
+	for i, node := range l.ttlIdx {
+		if now.After(node.ttl) {
+			pruneCount = i + 1
+			prunedConfigs = append(prunedConfigs, node.cacheKey)
+		} else {
+			break
+		}
+	}
+
+	if pruneCount > 0 {
+		// clear obsolete configs so that they can be garbage collected
+		clear(l.ttlIdx[:pruneCount])
+		l.ttlIdx = l.ttlIdx[pruneCount:]
+	}
+	return prunedConfigs
 }
 
 func instanceToPbObject(instance Instance) *typesv1.Object {

--- a/internal/config/ams_test.go
+++ b/internal/config/ams_test.go
@@ -119,14 +119,16 @@ func TestAMSLoader_StreamRecreation(t *testing.T) {
 				KeepAlive:      tt.keepStreamAlive,
 			})
 			conn, cleanup := createMockAMSServer(t, mockService)
-			defer cleanup()
-
 			instance := &agentv1.Instance{Id: []byte("test-instance")}
 			loader, err := config.NewAMSLoader(conn,
 				config.WithInstance(instance),
 				config.WithMaxStreamAge(tt.maxStreamAge))
 			require.NoError(t, err)
-			defer loader.Close()
+
+			t.Cleanup(func() {
+				loader.Close()
+				cleanup()
+			})
 
 			time.Sleep(tt.testDuration)
 
@@ -263,13 +265,15 @@ func TestAMSLoader_ListConfigs(t *testing.T) {
 			})
 
 			conn, cleanup := createMockAMSServer(t, mockService)
-			defer cleanup()
-
 			instance := &agentv1.Instance{Id: []byte("test-instance")}
 
 			loader, err := config.NewAMSLoader(conn, config.WithInstance(instance))
 			require.NoError(t, err)
-			defer loader.Close()
+
+			t.Cleanup(func() {
+				loader.Close()
+				cleanup()
+			})
 
 			if len(tt.configsToCache) > 0 {
 				mockService.SendUpdates(tt.configsToCache)
@@ -385,13 +389,15 @@ func TestAMSLoader_GetConfig(t *testing.T) {
 			})
 
 			conn, cleanup := createMockAMSServer(t, mockService)
-			defer cleanup()
-
 			instance := &agentv1.Instance{Id: []byte("test-instance")}
 
 			loader, err := config.NewAMSLoader(conn, config.WithInstance(instance))
 			require.NoError(t, err)
-			defer loader.Close()
+
+			t.Cleanup(func() {
+				loader.Close()
+				cleanup()
+			})
 
 			if len(tt.configsToCache) > 0 {
 				mockService.SendUpdates(tt.configsToCache)
@@ -622,13 +628,15 @@ func TestAMSLoader_Watch(t *testing.T) {
 			})
 
 			conn, cleanup := createMockAMSServer(t, mockService)
-			defer cleanup()
-
 			instance := &agentv1.Instance{Id: []byte("test-instance")}
 
 			loader, err := config.NewAMSLoader(conn, config.WithInstance(instance))
 			require.NoError(t, err)
-			defer loader.Close()
+
+			t.Cleanup(func() {
+				loader.Close()
+				cleanup()
+			})
 
 			watchCh := loader.Watch(config.Options{Filters: tt.filters})
 
@@ -741,15 +749,17 @@ func TestAMSLoader_InitialConfigsOnStreamRecreation(t *testing.T) {
 			})
 
 			conn, cleanup := createMockAMSServer(t, mockService)
-			defer cleanup()
-
 			instance := &agentv1.Instance{Id: []byte("test-instance")}
 
 			loader, err := config.NewAMSLoader(conn,
 				config.WithInstance(instance),
 				config.WithMaxStreamAge(tt.maxStreamAge))
 			require.NoError(t, err)
-			defer loader.Close()
+
+			t.Cleanup(func() {
+				loader.Close()
+				cleanup()
+			})
 
 			if len(tt.initialConfigs) > 0 {
 				mockService.SendUpdates(tt.initialConfigs)

--- a/internal/config/fs_test.go
+++ b/internal/config/fs_test.go
@@ -186,7 +186,7 @@ func TestFSLoader_Watch(t *testing.T) {
 
 			fl, err := config.NewFSLoader(tempDir, logger)
 			require.NoError(t, err)
-			defer fl.Close()
+			t.Cleanup(func() { fl.Close() })
 
 			instanceCh := fl.Watch(config.Options{})
 
@@ -236,7 +236,7 @@ func TestFSLoader_ListConfigs(t *testing.T) {
 
 	fl, err := config.NewFSLoader(tempDir, logger)
 	require.NoError(t, err)
-	defer fl.Close()
+	t.Cleanup(func() { fl.Close() })
 
 	configs, err := fl.ListConfigs(config.Options{})
 	require.NoError(t, err)
@@ -270,7 +270,7 @@ func TestFSLoader_GetConfig(t *testing.T) {
 
 	fl, err := config.NewFSLoader(tempDir, logger)
 	require.NoError(t, err)
-	defer fl.Close()
+	t.Cleanup(func() { fl.Close() })
 
 	hostStatsTypeName := string((&agentv1.HostStatsCollectionConfig{}).ProtoReflect().Descriptor().FullName())
 	instance, err := fl.GetConfig(hostStatsTypeName, "config1")
@@ -341,7 +341,7 @@ func TestFSLoader_FileChangeSubscription(t *testing.T) {
 
 			fl, err := config.NewFSLoader(tempDir, logger)
 			require.NoError(t, err)
-			defer fl.Close()
+			t.Cleanup(func() { fl.Close() })
 
 			instanceCh := fl.Watch(config.Options{})
 

--- a/internal/config/fs_test.go
+++ b/internal/config/fs_test.go
@@ -378,3 +378,48 @@ func TestFSLoader_FileChangeSubscription(t *testing.T) {
 		})
 	}
 }
+
+func TestFSLoader_FileDeleteSubscription(t *testing.T) {
+	t.Parallel()
+	logger := testr.New(t)
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config1.json")
+
+	initialConfig := createHostStatsJSON("config1", "cpu")
+	err := os.WriteFile(configFile, []byte(initialConfig), 0644)
+	require.NoError(t, err)
+
+	fl, err := config.NewFSLoader(tempDir, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { fl.Close() })
+
+	instanceCh := fl.Watch(config.Options{})
+
+	// Drain initial config from subscription (loaded at startup)
+	select {
+	case initialInstance := <-instanceCh:
+		assert.Equal(t, config.StatusOK, initialInstance.Status)
+		assert.Equal(t, "config1", initialInstance.Name)
+		assert.False(t, initialInstance.Expired)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for initial config")
+	}
+
+	// Delete the config file
+	err = os.Remove(configFile)
+	require.NoError(t, err)
+
+	// Should receive expired config via subscription
+	select {
+	case expiredInstance := <-instanceCh:
+		assert.Equal(t, "config1", expiredInstance.Name)
+		assert.True(t, expiredInstance.Expired, "Instance should be marked as expired")
+		assert.NotNil(t, expiredInstance.Object, "Object should still be present in expired instance")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for expired config via subscription")
+	}
+
+	// Verify config is removed from cache
+	_, err = fl.GetConfig(string((&agentv1.HostStatsCollectionConfig{}).ProtoReflect().Descriptor().FullName()), "config1")
+	assert.Error(t, err, "Config should not be found in cache after deletion")
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,6 +25,7 @@ type Instance struct {
 	Version string
 	Object  proto.Message
 	Status  Status
+	Expired bool
 }
 
 // Copy returns a deep copy of the Instance.
@@ -35,6 +36,7 @@ func (i *Instance) Copy() Instance {
 		Version: i.Version,
 		Object:  proto.Clone(i.Object),
 		Status:  i.Status,
+		Expired: i.Expired,
 	}
 }
 


### PR DESCRIPTION
Add Expired field to config.Instance. Expired makes whether the config is not longer applicable. Consumers can use this to clean up resouces that use that config.

Update filesystem config loader to handle file deletions. If a config is deleted, update the config Instance as Expired and send to subscribers. FSLoader ignores object TTL and has no effect if set.

Update agent management protocol loader to track config TTLs. Once the ttl on a config object is expired, it will be marked as Expired and sent to subscribers. AMSLoader also supports changing the ttl. If the TTL is extended, the lifetime of the config object is extend. If TTL is set to 0, then it is
treated as a perpetual static config. It can be updated only by sending a new version. Deleting a 0 TTL config is not supported (protocol doesn't allow for it and needs to be extended for this).