### PR TITLE
Find machine id in /var/lib/dbus/machine-id

### DIFF
--- a/config/agent/agent.yaml
+++ b/config/agent/agent.yaml
@@ -84,6 +84,10 @@ spec:
           value: /host/sys
         - name: HOST_DEV
           value: /host/dev
+        - name: HOST_ETC
+          value: /host/etc
+        - name: HOST_VAR
+          value: /host/var
         - name: HOST_CGROUP
           value: /host/cgroup
         volumeMounts:
@@ -97,6 +101,12 @@ spec:
           readOnly: true
         - name: dev
           mountPath: /host/dev
+          readOnly: true
+        - name: machine-id
+          mountPath: /host/etc/machine-id
+          readOnly: true
+        - name: dbus
+          mountPath: /host/var/lib/dbus
           readOnly: true
         - name: cgroup
           mountPath: /host/cgroup
@@ -143,6 +153,12 @@ spec:
         hostPath:
           path: /dev
           type: Directory
+      - name: machine-id
+        hostPath:
+          path: /etc/machine-id
+      - name: dbus
+        hostPath:
+          path: /var/lib/dbus
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup

--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker


### PR DESCRIPTION
`/etc/machine-id` is primarily set by systemd. Use `/var/lib/dbus/machine-id` as a fallback. Also use the `HOST_SYS`, `HOST_VAR`, and `HOST_ETC` env vars for `/sys`, `/var`, and `/etc` respectively 