### PR TITLE
chore: add otel collector to test cluster & enable performance manager

### DIFF
--- a/config/agent/agent.yaml
+++ b/config/agent/agent.yaml
@@ -60,7 +60,9 @@ spec:
         - /agent
         args:
         - --leader-elect
-        - --zap-log-level=debug
+        - --zap-log-level=2
+        - --enable-performance-collectors
+        - --enable-otel
         - --data-directory
         - ''
         image: agent
@@ -90,6 +92,10 @@ spec:
           value: /host/var
         - name: HOST_CGROUP
           value: /host/cgroup
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "collector.opentelemetry:4317"
+        - name: OTEL_EXPORTER_OTLP_INSECURE
+          value: "true"
         volumeMounts:
         - name: data
           mountPath: /var/lib/antimetal

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: antimetal-system
+
 resources:
 - agent.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: antimetal-system
-
 resources:
   - ../rbac
   - ../agent
   - ../test
+  - ../opentelemetry
   - ./metrics_service.yaml
 
 patches:

--- a/config/opentelemetry/collector.yaml
+++ b/config/opentelemetry/collector.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: collector
+  labels:
+    app: opentelemetry
+    component: collector
+spec:
+  ports:
+  - name: otlp-grpc # Default endpoint for OpenTelemetry gRPC receiver.
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: otlp-http # Default endpoint for OpenTelemetry HTTP receiver.
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: metrics # Default endpoint for querying metrics.
+    port: 8888
+  selector:
+    component: collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector
+  labels:
+    app: opentelemetry
+    component: collector
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: collector
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: collector
+    spec:
+      containers:
+      - command:
+          - "/otelcol"
+          - "--config=/conf/collector-config.yaml"
+        image: otel/opentelemetry-collector:latest
+        name: collector
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        ports:
+        - containerPort: 55679 # Default endpoint for ZPages.
+        - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 9411 # Default endpoint for Zipkin receiver.
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: GOMEMLIMIT
+            value: 1600MiB
+        volumeMounts:
+        - name: collector-config-vol
+          mountPath: /conf
+      volumes:
+        - configMap:
+            name: collector-conf
+            items:
+              - key: collector-config
+                path: collector-config.yaml
+          name: collector-config-vol

--- a/config/opentelemetry/collector_configmap.yaml
+++ b/config/opentelemetry/collector_configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-conf
+  labels:
+    app: opentelemetry
+    component: collector-conf
+data:
+  collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+    processors:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 1500
+        # 25% of limit up to 2G
+        spike_limit_mib: 512
+        check_interval: 5s
+    extensions:
+      zpages: {}
+    exporters:
+      nop:
+    service:
+      extensions: [zpages]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter]
+          exporters: [nop]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter]
+          exporters: [nop]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter]
+          exporters: [nop]

--- a/config/opentelemetry/kustomization.yaml
+++ b/config/opentelemetry/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opentelemetry
+
+resources:
+  - collector.yaml
+  - collector_configmap.yaml
+  - namespace.yaml

--- a/config/opentelemetry/namespace.yaml
+++ b/config/opentelemetry/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: antimetal-system
+
 resources:
 - service_account.yaml
 - role.yaml


### PR DESCRIPTION
`make deploy` deploys a opentelemetry collector alongside the system agent, which now runs the performance collectors and exports the metrics to the collector.