### PR TITLE
build: add -trimpath flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
     main: ./cmd/main.go
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -X "github.com/antimetal/agent/internal/runtime.buildMajor={{ .Major }}"
       - -X "github.com/antimetal/agent/internal/runtime.buildMinor={{ .Minor }}"


### PR DESCRIPTION
Remove file system paths from the agent binary, replacing it with modules or import paths. This makes debugging more useful (e.g. can better search source code for pprof profiles with go tool pprof).