### PR TITLE
Ensure that K8s resources make it to the graph when resource store disk persistence is enabled

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+run:
+  timeout: 10m
+
+output:
+  show-stats: true
+
+linters:
+  default: standard
+  enable:
+    - gofmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ Always run `make generate` after:
 - Mock external dependencies (gRPC, AWS, K8s)
 
 #### Git Commits and PRs
+- **ALWAYS** run `make lint-fix` before creating a commit
 - **ALWAYS** use the `commit-author` agent for creating commit messages, reviewing commits, or generating PR descriptions
 - The agent ensures compliance with project commit conventions and formatting standards
 

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,11 @@ test-integration: generate manifests build-ebpf ## Run integration tests with co
 
 .PHONY: lint
 lint: golangci-lint generate ## Run golangci-lint linter & yamllint.
-	$(GOLANGCI_LINT) run --timeout 10m
+	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
 lint-fix: golangci-lint generate ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run --fix --timeout 10m
+	$(GOLANGCI_LINT) run --fix
 
 ##@ eBPF
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,11 +36,11 @@ import (
 	"github.com/antimetal/agent/internal/metrics"
 	"github.com/antimetal/agent/internal/metrics/consumers/debug"
 	"github.com/antimetal/agent/internal/metrics/consumers/otel"
+	"github.com/antimetal/agent/internal/resource/store"
 	"github.com/antimetal/agent/internal/runtime"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/performance"
 	_ "github.com/antimetal/agent/pkg/performance/collectors" // Register collectors
-	"github.com/antimetal/agent/internal/resource/store"
 )
 
 var (

--- a/config/agent/agent.yaml
+++ b/config/agent/agent.yaml
@@ -63,8 +63,6 @@ spec:
         - --zap-log-level=2
         - --enable-performance-collectors
         - --enable-otel
-        - --data-directory
-        - ''
         image: agent
         ports: []
         env:

--- a/internal/hardware/graph/builder.go
+++ b/internal/hardware/graph/builder.go
@@ -11,9 +11,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/antimetal/agent/internal/resource"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/performance"
-	"github.com/antimetal/agent/internal/resource"
 	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"

--- a/internal/hardware/graph/builder_test.go
+++ b/internal/hardware/graph/builder_test.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/antimetal/agent/internal/hardware/graph"
+	"github.com/antimetal/agent/internal/resource"
+	"github.com/antimetal/agent/internal/resource/store"
 	hardwarev1 "github.com/antimetal/agent/pkg/api/antimetal/hardware/v1"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/performance"
-	"github.com/antimetal/agent/internal/resource"
-	"github.com/antimetal/agent/internal/resource/store"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,7 +132,7 @@ func TestBuilder_BuildFromSnapshot(t *testing.T) {
 				},
 			},
 			DiskInfo: []*performance.DiskInfo{
-				&performance.DiskInfo{
+				{
 					Device:            "nvme0n1",
 					Model:             "Amazon Elastic Block Store",
 					Vendor:            "NVMe",
@@ -152,7 +152,7 @@ func TestBuilder_BuildFromSnapshot(t *testing.T) {
 				},
 			},
 			NetworkInfo: []*performance.NetworkInfo{
-				&performance.NetworkInfo{
+				{
 					Interface:  "eth0",
 					MACAddress: "02:42:ac:11:00:02",
 					Speed:      10000, // 10Gbps

--- a/internal/hardware/manager.go
+++ b/internal/hardware/manager.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/antimetal/agent/internal/hardware/graph"
-	"github.com/antimetal/agent/pkg/performance"
 	"github.com/antimetal/agent/internal/resource"
+	"github.com/antimetal/agent/pkg/performance"
 	"github.com/go-logr/logr"
 )
 

--- a/internal/intake/worker.go
+++ b/internal/intake/worker.go
@@ -19,9 +19,9 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/antimetal/agent/internal/resource"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	intakev1 "github.com/antimetal/agent/pkg/api/service/resource/v1"
-	"github.com/antimetal/agent/internal/resource"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/internal/kubernetes/agent/controller.go
+++ b/internal/kubernetes/agent/controller.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/antimetal/agent/pkg/errors"
 	"github.com/antimetal/agent/internal/resource"
+	"github.com/antimetal/agent/pkg/errors"
 	"github.com/go-logr/logr"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"golang.org/x/sync/errgroup"

--- a/internal/kubernetes/agent/controller.go
+++ b/internal/kubernetes/agent/controller.go
@@ -149,6 +149,8 @@ func (c *controller) Start(ctx context.Context) error {
 		return fmt.Errorf("controller was started more than once. This can be caused by being added to a manager multiple times")
 	}
 
+	c.logger.V(1).Info("Starting controller")
+
 	major, minor, err := c.getKubeVersion()
 	if err != nil {
 		return fmt.Errorf("failed to get k8s version: %w", err)
@@ -183,10 +185,10 @@ func (c *controller) Shutdown() {
 	c.started = false
 }
 
-// Implements. sigs.k8s.io/controller-runtime/pkg/manager.LeaderElectionRunnable interface
-// so that the controller-runtime Manager knows that this controller needs leader election.
+// Implements sigs.k8s.io/controller-runtime/pkg/manager.LeaderElectionRunnable interface
+// Always returns false to disable leader election.
 func (c *controller) NeedLeaderElection() bool {
-	return true
+	return false
 }
 
 func (c *controller) indexWorker(ctx context.Context) {

--- a/internal/kubernetes/agent/generate.go
+++ b/internal/kubernetes/agent/generate.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 
 	"github.com/antimetal/agent/internal/kubernetes/scheme"
+	"github.com/antimetal/agent/internal/resource"
 	k8sv1 "github.com/antimetal/agent/pkg/api/kubernetes/v1"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/errors"
-	"github.com/antimetal/agent/internal/resource"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	appsv1 "k8s.io/api/apps/v1"

--- a/internal/kubernetes/agent/indexer.go
+++ b/internal/kubernetes/agent/indexer.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 
 	"github.com/antimetal/agent/internal/kubernetes/cluster"
+	"github.com/antimetal/agent/internal/resource"
 	k8sv1 "github.com/antimetal/agent/pkg/api/kubernetes/v1"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/errors"
-	"github.com/antimetal/agent/internal/resource"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"

--- a/internal/resource/store/logger.go
+++ b/internal/resource/store/logger.go
@@ -6,7 +6,11 @@
 
 package store
 
-import "github.com/go-logr/logr"
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
 
 // badgerLogger wraps a logr.Logger to implement the badger.Logger interface
 type badgerLogger struct {
@@ -20,22 +24,22 @@ func newBadgerLogger(log logr.Logger) *badgerLogger {
 
 // Errorf logs an ERROR level message
 func (l *badgerLogger) Errorf(format string, args ...any) {
-	l.log.Error(nil, format, args...)
+	l.log.Error(nil, fmt.Sprintf(format, args...))
 }
 
 // Warningf logs a WARNING level message
 func (l *badgerLogger) Warningf(format string, args ...any) {
 	// Map warning to info since logr doesn't have a warning level
-	l.log.Info(format, args...)
+	l.log.Info(fmt.Sprintf(format, args...))
 }
 
 // Infof logs an INFO level message
 func (l *badgerLogger) Infof(format string, args ...any) {
-	l.log.Info(format, args...)
+	l.log.Info(fmt.Sprintf(format, args...))
 }
 
 // Debugf logs a DEBUG level message
 func (l *badgerLogger) Debugf(format string, args ...any) {
 	// Use V(1) for debug level logging
-	l.log.V(1).Info(format, args...)
+	l.log.V(1).Info(fmt.Sprintf(format, args...))
 }

--- a/internal/resource/store/store.go
+++ b/internal/resource/store/store.go
@@ -24,8 +24,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/antimetal/agent/pkg/errors"
 	"github.com/antimetal/agent/internal/resource"
+	"github.com/antimetal/agent/pkg/errors"
 )
 
 const (

--- a/internal/resource/store/store.go
+++ b/internal/resource/store/store.go
@@ -661,8 +661,8 @@ func (s *store) sendInitialObjects(subscriber *subscriber) {
 					objs = append(objs, &resourcev1.Object{
 						Type: r.GetType(),
 						Object: &anypb.Any{
-							TypeUrl: fmt.Sprintf("%s/%s", "type.googleapis.com", r.GetType().GetType()),
-							Value:   val,
+							TypeUrl: fmt.Sprintf("%s/%s", "type.googleapis.com", proto.MessageName(r)),
+							Value:   bytes.Clone(val),
 						},
 					})
 				}
@@ -682,8 +682,11 @@ func (s *store) sendInitialObjects(subscriber *subscriber) {
 				}
 				if subscriber.match(rel.GetType()) {
 					objs = append(objs, &resourcev1.Object{
-						Type:   rel.GetType(),
-						Object: &anypb.Any{Value: val},
+						Type: rel.GetType(),
+						Object: &anypb.Any{
+							TypeUrl: fmt.Sprintf("%s/%s", "type.googleapis.com", proto.MessageName(rel)),
+							Value:   bytes.Clone(val),
+						},
 					})
 				}
 				return nil

--- a/internal/resource/store/store_test.go
+++ b/internal/resource/store/store_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/antimetal/agent/internal/resource"
 	resourcev1 "github.com/antimetal/agent/pkg/api/resource/v1"
 	"github.com/antimetal/agent/pkg/errors"
-	"github.com/antimetal/agent/internal/resource"
 	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"


### PR DESCRIPTION
- Disable leader election on Kubernetes controller for single-instance operation: we're going with the architecture that every replica watches for K8s resources from the API server but only 1 has the k8s-intake-worker running via leader election. This is not super scalable for very large clusters since this could overload the API server but we can deal with that later.

- Align resource types for proper initial object creation on store subscriptions

Misc
- Improve BadgerDB logger string formatting for better debugging
- add golangci-lint config file that checks that files are gofmted.