### PR TITLE
refactor(perf): create an Event type that collectors return

### DIFF
--- a/cmd/examples/execsnoop/main.go
+++ b/cmd/examples/execsnoop/main.go
@@ -66,7 +66,7 @@ func main() {
 				fmt.Printf("\nProcessed %d events\n", eventCount)
 				return
 			}
-			if execEvent, ok := event.(*collectors.ExecEvent); ok {
+			if execEvent, ok := event.Data.(*collectors.ExecEvent); ok {
 				eventCount++
 				fmt.Printf("[%d] PID=%d PPID=%d UID=%d CMD=%s ARGS=%v RetVal=%d\n",
 					eventCount, execEvent.PID, execEvent.PPID, execEvent.UID,

--- a/internal/config/internal/mock/collector.go
+++ b/internal/config/internal/mock/collector.go
@@ -35,8 +35,8 @@ func (m *Collector) Capabilities() performance.CollectorCapabilities {
 	}
 }
 
-func (m *Collector) Start(ctx context.Context) (<-chan any, error) {
-	ch := make(chan any, 1)
+func (m *Collector) Start(ctx context.Context) (<-chan performance.Event, error) {
+	ch := make(chan performance.Event, 1)
 	close(ch)
 	return ch, nil
 }

--- a/internal/hardware/manager.go
+++ b/internal/hardware/manager.go
@@ -211,15 +211,15 @@ func (m *Manager) collectHardwareSnapshot(ctx context.Context) (*types.Snapshot,
 		// Store the collected data in the snapshot based on type
 		switch metricType {
 		case performance.MetricTypeCPUInfo:
-			snapshot.CPUInfo = data.(*performance.CPUInfo)
+			snapshot.CPUInfo = data.Data.(*performance.CPUInfo)
 		case performance.MetricTypeMemoryInfo:
-			snapshot.MemoryInfo = data.(*performance.MemoryInfo)
+			snapshot.MemoryInfo = data.Data.(*performance.MemoryInfo)
 		case performance.MetricTypeDiskInfo:
-			snapshot.DiskInfo = data.([]*performance.DiskInfo)
+			snapshot.DiskInfo = data.Data.([]*performance.DiskInfo)
 		case performance.MetricTypeNetworkInfo:
-			snapshot.NetworkInfo = data.([]*performance.NetworkInfo)
+			snapshot.NetworkInfo = data.Data.([]*performance.NetworkInfo)
 		case performance.MetricTypeNUMAStats:
-			snapshot.NUMAStats = data.(*performance.NUMAStatistics)
+			snapshot.NUMAStats = data.Data.(*performance.NUMAStatistics)
 		}
 
 		snapshot.CollectorRun.CollectorStats[metricType] = performance.CollectorStat{

--- a/pkg/kernel/kernel_compat_integration_test.go
+++ b/pkg/kernel/kernel_compat_integration_test.go
@@ -194,11 +194,11 @@ func TestCollectorCompatibility(t *testing.T) {
 
 			// Wait for at least one data point
 			select {
-			case data := <-ch:
-				if data == nil {
+			case event := <-ch:
+				if event.Data == nil {
 					t.Errorf("%s produced nil data", tc.name)
 				} else {
-					t.Logf("✓ %s: Successfully collected data of type %T", tc.name, data)
+					t.Logf("✓ %s: Successfully collected data of type %T", tc.name, event.Data)
 				}
 			case <-ctx.Done():
 				t.Errorf("%s: Timeout waiting for data", tc.name)

--- a/pkg/performance/collectors/cgroup_cpu_test.go
+++ b/pkg/performance/collectors/cgroup_cpu_test.go
@@ -85,7 +85,7 @@ func TestCgroupCPUCollector_CgroupV1(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupCPUStats)
+	stats, ok := result.Data.([]performance.CgroupCPUStats)
 	require.True(t, ok, "result should be []performance.CgroupCPUStats")
 	require.Len(t, stats, 2, "should find 2 containers")
 
@@ -125,7 +125,7 @@ func TestCgroupCPUCollector_CgroupV2(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupCPUStats)
+	stats, ok := result.Data.([]performance.CgroupCPUStats)
 	require.True(t, ok, "result should be []performance.CgroupCPUStats")
 	require.Len(t, stats, 2, "should find 2 containers")
 
@@ -190,7 +190,7 @@ throttled_time 1000000000`)
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupCPUStats)
+	stats, ok := result.Data.([]performance.CgroupCPUStats)
 	require.True(t, ok)
 	require.Len(t, stats, 1)
 

--- a/pkg/performance/collectors/cgroup_memory_test.go
+++ b/pkg/performance/collectors/cgroup_memory_test.go
@@ -85,7 +85,7 @@ func TestCgroupMemoryCollector_CgroupV1(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupMemoryStats)
+	stats, ok := result.Data.([]performance.CgroupMemoryStats)
 	require.True(t, ok, "result should be []performance.CgroupMemoryStats")
 	require.Len(t, stats, 2, "should find 2 containers")
 
@@ -123,7 +123,7 @@ func TestCgroupMemoryCollector_CgroupV2(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupMemoryStats)
+	stats, ok := result.Data.([]performance.CgroupMemoryStats)
 	require.True(t, ok, "result should be []performance.CgroupMemoryStats")
 	require.Len(t, stats, 2, "should find 2 containers")
 
@@ -189,7 +189,7 @@ swap 0`)
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupMemoryStats)
+	stats, ok := result.Data.([]performance.CgroupMemoryStats)
 	require.True(t, ok)
 	require.Len(t, stats, 1)
 
@@ -229,7 +229,7 @@ oom_kill 10`)
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]performance.CgroupMemoryStats)
+	stats, ok := result.Data.([]performance.CgroupMemoryStats)
 	require.True(t, ok)
 	require.Len(t, stats, 1)
 

--- a/pkg/performance/collectors/cpu.go
+++ b/pkg/performance/collectors/cpu.go
@@ -69,13 +69,13 @@ func NewCPUCollector(logger logr.Logger, config performance.CollectionConfig) (*
 }
 
 // Collect performs a one-shot collection of CPU statistics
-func (c *CPUCollector) Collect(ctx context.Context) (any, error) {
+func (c *CPUCollector) Collect(ctx context.Context) (performance.Event, error) {
 	currentTime := time.Now()
 
 	// Collect current statistics
 	currentStats, err := c.collectCPUStats()
 	if err != nil {
-		return nil, fmt.Errorf("failed to collect CPU stats: %w", err)
+		return performance.Event{}, fmt.Errorf("failed to collect CPU stats: %w", err)
 	}
 
 	shouldCalc, reason := c.ShouldCalculateDeltas(currentTime)
@@ -84,20 +84,20 @@ func (c *CPUCollector) Collect(ctx context.Context) (any, error) {
 		if c.IsFirst {
 			c.UpdateDeltaState(currentStats, currentTime)
 		}
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeCPU, Data: currentStats}, nil
 	}
 
 	previousStats, ok := c.LastSnapshot.([]*performance.CPUStats)
 	if !ok || previousStats == nil {
 		c.UpdateDeltaState(currentStats, currentTime)
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeCPU, Data: currentStats}, nil
 	}
 
 	c.calculateCPUDeltas(currentStats, previousStats, currentTime, c.Config)
 	c.UpdateDeltaState(currentStats, currentTime)
 
 	c.Logger().V(1).Info("Collected CPU statistics with delta support", "cpus", len(currentStats))
-	return currentStats, nil
+	return performance.Event{Metric: performance.MetricTypeCPU, Data: currentStats}, nil
 }
 
 // collectCPUStats reads and parses /proc/stat for CPU statistics

--- a/pkg/performance/collectors/cpu_info.go
+++ b/pkg/performance/collectors/cpu_info.go
@@ -78,8 +78,12 @@ func NewCPUInfoCollector(logger logr.Logger, config performance.CollectionConfig
 	}, nil
 }
 
-func (c *CPUInfoCollector) Collect(ctx context.Context) (any, error) {
-	return c.collectCPUInfo()
+func (c *CPUInfoCollector) Collect(ctx context.Context) (performance.Event, error) {
+	info, err := c.collectCPUInfo()
+	if err != nil {
+		return performance.Event{}, err
+	}
+	return performance.Event{Metric: performance.MetricTypeCPUInfo, Data: info}, nil
 }
 
 func (c *CPUInfoCollector) collectCPUInfo() (*performance.CPUInfo, error) {

--- a/pkg/performance/collectors/cpu_info_test.go
+++ b/pkg/performance/collectors/cpu_info_test.go
@@ -493,7 +493,7 @@ func TestCPUInfoCollector_Collect(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			info, ok := result.(*performance.CPUInfo)
+			info, ok := result.Data.(*performance.CPUInfo)
 			require.True(t, ok, "Expected *performance.CPUInfo, got %T", result)
 
 			if tt.wantInfo != nil {
@@ -532,7 +532,7 @@ cpu cores	: 4
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, int32(4), info.LogicalCores)
@@ -558,7 +558,7 @@ vendor_id: Intel
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	// Should handle parsing errors gracefully
@@ -635,7 +635,7 @@ power management: ts ttp tm hwpstate cpb eff_freq_ro [13] [14]
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "AuthenticAMD", info.VendorID)
@@ -719,7 +719,7 @@ power management:
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "AuthenticAMD", info.VendorID)
@@ -783,7 +783,7 @@ CPU revision	: 4
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, float64(48.00), info.BogoMIPS)
@@ -824,7 +824,7 @@ Serial		: 304d19f36a02309e
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, float64(1592.52), info.BogoMIPS) // First processor's BogoMIPS
@@ -869,7 +869,7 @@ Serial		: 5400503583203c3c040e
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, float64(2400.00), info.BogoMIPS)
@@ -946,7 +946,7 @@ power management:
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "GenuineIntel", info.VendorID)
@@ -1078,7 +1078,7 @@ power management:
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "GenuineIntel", info.VendorID)
@@ -1160,7 +1160,7 @@ power management:
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "GenuineIntel", info.VendorID)
@@ -1241,7 +1241,7 @@ power management:
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	assert.Equal(t, "GenuineIntel", info.VendorID)
@@ -1284,7 +1284,7 @@ pmac-generation : NewWorld
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.CPUInfo)
+	info, ok := result.Data.(*performance.CPUInfo)
 	require.True(t, ok)
 
 	// PowerPC doesn't have vendor_id, model name, or numeric CPU identification

--- a/pkg/performance/collectors/cpu_test.go
+++ b/pkg/performance/collectors/cpu_test.go
@@ -211,7 +211,7 @@ cpu7 250 0 250 2000 0 0 0 0 0 0
 			}
 
 			require.NoError(t, err)
-			stats, ok := result.([]*performance.CPUStats)
+			stats, ok := result.Data.([]*performance.CPUStats)
 			require.True(t, ok, "Expected []*performance.CPUStats")
 
 			if tt.validate != nil {
@@ -250,7 +250,7 @@ procs_blocked 0
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.([]*performance.CPUStats)
+	stats, ok := result.Data.([]*performance.CPUStats)
 	require.True(t, ok, "Expected []*performance.CPUStats")
 	require.Len(t, stats, 3) // cpu, cpu0, cpu1
 

--- a/pkg/performance/collectors/disk.go
+++ b/pkg/performance/collectors/disk.go
@@ -78,10 +78,10 @@ func NewDiskCollector(logger logr.Logger, config performance.CollectionConfig) (
 }
 
 // Collect performs a one-shot collection of disk statistics
-func (c *DiskCollector) Collect(ctx context.Context) (any, error) {
+func (c *DiskCollector) Collect(ctx context.Context) (performance.Event, error) {
 	stats, err := c.collectDiskStats()
 	if err != nil {
-		return nil, fmt.Errorf("failed to collect disk stats: %w", err)
+		return performance.Event{}, fmt.Errorf("failed to collect disk stats: %w", err)
 	}
 
 	currentTime := time.Now()
@@ -98,7 +98,7 @@ func (c *DiskCollector) Collect(ctx context.Context) (any, error) {
 	c.UpdateDeltaState(stats, currentTime)
 
 	c.Logger().V(1).Info("Collected disk statistics", "devices", len(stats))
-	return stats, nil
+	return performance.Event{Metric: performance.MetricTypeDisk, Data: stats}, nil
 }
 
 // collectDiskStats reads and parses /proc/diskstats

--- a/pkg/performance/collectors/disk_info.go
+++ b/pkg/performance/collectors/disk_info.go
@@ -99,8 +99,12 @@ func NewDiskInfoCollector(logger logr.Logger, config performance.CollectionConfi
 	}, nil
 }
 
-func (c *DiskInfoCollector) Collect(ctx context.Context) (any, error) {
-	return c.collectDiskInfo()
+func (c *DiskInfoCollector) Collect(ctx context.Context) (performance.Event, error) {
+	info, err := c.collectDiskInfo()
+	if err != nil {
+		return performance.Event{}, err
+	}
+	return performance.Event{Metric: performance.MetricTypeDiskInfo, Data: info}, nil
 }
 
 // collectDiskInfo discovers and collects hardware information for all block devices.

--- a/pkg/performance/collectors/disk_info_test.go
+++ b/pkg/performance/collectors/disk_info_test.go
@@ -295,7 +295,7 @@ func TestDiskInfoCollector_Collect(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			disks, ok := result.([]*performance.DiskInfo)
+			disks, ok := result.Data.([]*performance.DiskInfo)
 			require.True(t, ok, "Expected []*performance.DiskInfo, got %T", result)
 
 			if tt.wantInfo != nil {
@@ -328,7 +328,7 @@ func TestDiskInfoCollector_PartitionDetectionWithSoftwareRAID(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	disks, ok := result.([]*performance.DiskInfo)
+	disks, ok := result.Data.([]*performance.DiskInfo)
 	require.True(t, ok)
 
 	// Should include: sda (whole disk) and md0 (software RAID device)

--- a/pkg/performance/collectors/disk_test.go
+++ b/pkg/performance/collectors/disk_test.go
@@ -70,7 +70,7 @@ func collectDiskStats(t *testing.T, collector *collectors.DiskCollector) []*perf
 	result, err := collector.Collect(ctx)
 	require.NoError(t, err)
 
-	stats, ok := result.([]*performance.DiskStats)
+	stats, ok := result.Data.([]*performance.DiskStats)
 	require.True(t, ok, "expected []*performance.DiskStats, got %T", result)
 	return stats
 }

--- a/pkg/performance/collectors/execsnoop.go
+++ b/pkg/performance/collectors/execsnoop.go
@@ -58,7 +58,7 @@ type ExecSnoopCollector struct {
 	enterLink     link.Link
 	exitLink      link.Link
 	reader        *ringbuf.Reader
-	outputChan    chan any
+	outputChan    chan performance.Event
 }
 
 func NewExecSnoopCollector(logger logr.Logger, config performance.CollectionConfig, bpfObjectPath string) (*ExecSnoopCollector, error) {
@@ -91,7 +91,7 @@ func NewExecSnoopCollector(logger logr.Logger, config performance.CollectionConf
 	return collector, nil
 }
 
-func (c *ExecSnoopCollector) Start(ctx context.Context) (<-chan any, error) {
+func (c *ExecSnoopCollector) Start(ctx context.Context) (<-chan performance.Event, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -167,7 +167,7 @@ func (c *ExecSnoopCollector) Start(ctx context.Context) (<-chan any, error) {
 	}
 
 	// Create output channel
-	c.outputChan = make(chan any, 100)
+	c.outputChan = make(chan performance.Event, 100)
 
 	// Start reading events
 	go c.readEvents(ctx)
@@ -232,7 +232,7 @@ func (c *ExecSnoopCollector) readEvents(ctx context.Context) {
 			}
 
 			select {
-			case c.outputChan <- event:
+			case c.outputChan <- performance.Event{Metric: performance.MetricTypeProcess, Data: event}:
 			case <-ctx.Done():
 				return
 			default:

--- a/pkg/performance/collectors/execsnoop_integration_test.go
+++ b/pkg/performance/collectors/execsnoop_integration_test.go
@@ -60,7 +60,7 @@ func TestExecSnoopCollector_Integration(t *testing.T) {
 			for {
 				select {
 				case event := <-eventChan:
-					if execEvent, ok := event.(*collectors.ExecEvent); ok {
+					if execEvent, ok := event.Data.(*collectors.ExecEvent); ok {
 						events = append(events, execEvent)
 						// Look for our test commands
 						if execEvent.Command == "echo" || execEvent.Command == "true" {

--- a/pkg/performance/collectors/load.go
+++ b/pkg/performance/collectors/load.go
@@ -66,8 +66,12 @@ func NewLoadCollector(logger logr.Logger, config performance.CollectionConfig) (
 	}, nil
 }
 
-func (c *LoadCollector) Collect(ctx context.Context) (any, error) {
-	return c.collectLoadStats()
+func (c *LoadCollector) Collect(ctx context.Context) (performance.Event, error) {
+	stats, err := c.collectLoadStats()
+	if err != nil {
+		return performance.Event{}, err
+	}
+	return performance.Event{Metric: performance.MetricTypeLoad, Data: stats}, nil
 }
 
 // collectLoadStats reads and parses /proc/loadavg and /proc/uptime

--- a/pkg/performance/collectors/load_test.go
+++ b/pkg/performance/collectors/load_test.go
@@ -245,7 +245,7 @@ func TestLoadCollector_MissingFiles(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			stats, ok := result.(*performance.LoadStats)
+			stats, ok := result.Data.(*performance.LoadStats)
 			require.True(t, ok)
 
 			// For missing uptime case, should have zero uptime but valid load data
@@ -424,7 +424,7 @@ func TestLoadCollector_DataParsing(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			stats, ok := result.(*performance.LoadStats)
+			stats, ok := result.Data.(*performance.LoadStats)
 			require.True(t, ok)
 			validateLoadStats(t, stats, tt.expected)
 		})
@@ -678,7 +678,7 @@ func TestLoadCollector_BlockedProcsIntegration(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			stats, ok := result.(*performance.LoadStats)
+			stats, ok := result.Data.(*performance.LoadStats)
 			require.True(t, ok, "result should be *performance.LoadStats")
 
 			validateLoadStats(t, stats, tt.expected)
@@ -713,7 +713,7 @@ func TestLoadCollector_StatPermissions(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.(*performance.LoadStats)
+	stats, ok := result.Data.(*performance.LoadStats)
 	require.True(t, ok)
 
 	// Load data should be present
@@ -752,7 +752,7 @@ func TestLoadCollector_StatAsDirectory(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.(*performance.LoadStats)
+	stats, ok := result.Data.(*performance.LoadStats)
 	require.True(t, ok)
 
 	// Load data should be present
@@ -768,7 +768,7 @@ func TestLoadCollector_AllFieldsWithStat(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	stats, ok := result.(*performance.LoadStats)
+	stats, ok := result.Data.(*performance.LoadStats)
 	require.True(t, ok, "result should be *performance.LoadStats")
 
 	// Verify all fields including the new BlockedProcs

--- a/pkg/performance/collectors/memory.go
+++ b/pkg/performance/collectors/memory.go
@@ -95,13 +95,13 @@ func NewMemoryCollector(logger logr.Logger, config performance.CollectionConfig)
 }
 
 // Collect performs a one-shot collection of memory statistics
-func (c *MemoryCollector) Collect(ctx context.Context) (any, error) {
+func (c *MemoryCollector) Collect(ctx context.Context) (performance.Event, error) {
 	currentTime := time.Now()
 
 	// Collect current statistics
 	currentStats, err := c.collectMemoryStats()
 	if err != nil {
-		return nil, fmt.Errorf("failed to collect memory stats: %w", err)
+		return performance.Event{}, fmt.Errorf("failed to collect memory stats: %w", err)
 	}
 
 	shouldCalc, reason := c.ShouldCalculateDeltas(currentTime)
@@ -111,21 +111,21 @@ func (c *MemoryCollector) Collect(ctx context.Context) (any, error) {
 			c.UpdateDeltaState(currentStats, currentTime)
 		}
 		c.Logger().V(1).Info("Collected memory statistics")
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeMemory, Data: currentStats}, nil
 	}
 
 	previousStats, ok := c.LastSnapshot.(*performance.MemoryStats)
 	if !ok || previousStats == nil {
 		c.UpdateDeltaState(currentStats, currentTime)
 		c.Logger().V(1).Info("Collected memory statistics")
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeMemory, Data: currentStats}, nil
 	}
 
 	c.calculateMemoryDeltas(currentStats, previousStats, currentTime, c.Config)
 	c.UpdateDeltaState(currentStats, currentTime)
 
 	c.Logger().V(1).Info("Collected memory statistics with delta support")
-	return currentStats, nil
+	return performance.Event{Metric: performance.MetricTypeMemory, Data: currentStats}, nil
 }
 
 // collectMemoryStats reads and parses runtime memory statistics from /proc/meminfo and /proc/vmstat

--- a/pkg/performance/collectors/memory_info.go
+++ b/pkg/performance/collectors/memory_info.go
@@ -129,8 +129,12 @@ func NewMemoryInfoCollector(logger logr.Logger, config performance.CollectionCon
 	}, nil
 }
 
-func (c *MemoryInfoCollector) Collect(ctx context.Context) (any, error) {
-	return c.collectMemoryInfo()
+func (c *MemoryInfoCollector) Collect(ctx context.Context) (performance.Event, error) {
+	info, err := c.collectMemoryInfo()
+	if err != nil {
+		return performance.Event{}, err
+	}
+	return performance.Event{Metric: performance.MetricTypeMemoryInfo, Data: info}, nil
 }
 
 // collectMemoryInfo discovers and collects memory hardware configuration.

--- a/pkg/performance/collectors/memory_info_test.go
+++ b/pkg/performance/collectors/memory_info_test.go
@@ -317,7 +317,7 @@ func TestMemoryInfoCollector_Collect(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			info, ok := result.(*performance.MemoryInfo)
+			info, ok := result.Data.(*performance.MemoryInfo)
 			require.True(t, ok, "Expected *performance.MemoryInfo, got %T", result)
 
 			if tt.wantInfo != nil {
@@ -348,7 +348,7 @@ func TestMemoryInfoCollector_ComplexCPUList(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.MemoryInfo)
+	info, ok := result.Data.(*performance.MemoryInfo)
 	require.True(t, ok)
 
 	assert.Len(t, info.NUMANodes, 1)
@@ -383,7 +383,7 @@ func TestMemoryInfoCollector_EmptyCPUList(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
 
-	info, ok := result.(*performance.MemoryInfo)
+	info, ok := result.Data.(*performance.MemoryInfo)
 	require.True(t, ok)
 
 	assert.Len(t, info.NUMANodes, 1)

--- a/pkg/performance/collectors/memory_test.go
+++ b/pkg/performance/collectors/memory_test.go
@@ -359,7 +359,7 @@ func collectAndValidateMemory(t *testing.T, collector *MemoryCollector, wantErr 
 	}
 
 	require.NoError(t, err)
-	stats, ok := result.(*performance.MemoryStats)
+	stats, ok := result.Data.(*performance.MemoryStats)
 	require.True(t, ok)
 	return stats
 }

--- a/pkg/performance/collectors/network.go
+++ b/pkg/performance/collectors/network.go
@@ -75,10 +75,10 @@ func NewNetworkCollector(logger logr.Logger, config performance.CollectionConfig
 	}, nil
 }
 
-func (c *NetworkCollector) Collect(ctx context.Context) (any, error) {
+func (c *NetworkCollector) Collect(ctx context.Context) (performance.Event, error) {
 	stats, err := c.collectNetworkStats()
 	if err != nil {
-		return nil, fmt.Errorf("failed to collect network stats: %w", err)
+		return performance.Event{}, fmt.Errorf("failed to collect network stats: %w", err)
 	}
 
 	currentTime := time.Now()
@@ -95,7 +95,7 @@ func (c *NetworkCollector) Collect(ctx context.Context) (any, error) {
 	c.UpdateDeltaState(stats, currentTime)
 
 	c.Logger().V(1).Info("Collected network statistics", "interfaces", len(stats))
-	return stats, nil
+	return performance.Event{Metric: performance.MetricTypeNetwork, Data: stats}, nil
 }
 
 // collectNetworkStats reads and parses /proc/net/dev and /sys/class/net/[interface]/*

--- a/pkg/performance/collectors/network_info.go
+++ b/pkg/performance/collectors/network_info.go
@@ -98,8 +98,12 @@ func NewNetworkInfoCollector(logger logr.Logger, config performance.CollectionCo
 	}, nil
 }
 
-func (c *NetworkInfoCollector) Collect(ctx context.Context) (any, error) {
-	return c.collectNetworkInfo()
+func (c *NetworkInfoCollector) Collect(ctx context.Context) (performance.Event, error) {
+	info, err := c.collectNetworkInfo()
+	if err != nil {
+		return performance.Event{}, err
+	}
+	return performance.Event{Metric: performance.MetricTypeNetworkInfo, Data: info}, nil
 }
 
 // collectNetworkInfo discovers and collects information for all network interfaces.

--- a/pkg/performance/collectors/network_info_test.go
+++ b/pkg/performance/collectors/network_info_test.go
@@ -289,7 +289,7 @@ func TestNetworkInfoCollector_Collect(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			interfaces, ok := result.([]*performance.NetworkInfo)
+			interfaces, ok := result.Data.([]*performance.NetworkInfo)
 			require.True(t, ok, "Expected []*performance.NetworkInfo, got %T", result)
 
 			if tt.wantInfo != nil {
@@ -379,7 +379,7 @@ func TestNetworkInfoCollector_InterfaceTypes(t *testing.T) {
 			result, err := collector.Collect(context.Background())
 			require.NoError(t, err)
 
-			interfaces, ok := result.([]*performance.NetworkInfo)
+			interfaces, ok := result.Data.([]*performance.NetworkInfo)
 			require.True(t, ok)
 			require.Len(t, interfaces, 1)
 

--- a/pkg/performance/collectors/network_test.go
+++ b/pkg/performance/collectors/network_test.go
@@ -124,7 +124,7 @@ func collectAndValidateNetwork(t *testing.T, collector *collectors.NetworkCollec
 	}
 
 	require.NoError(t, err)
-	stats, ok := result.([]*performance.NetworkStats)
+	stats, ok := result.Data.([]*performance.NetworkStats)
 	require.True(t, ok, "result should be []*performance.NetworkStats")
 
 	if validate != nil {

--- a/pkg/performance/collectors/numa_stats.go
+++ b/pkg/performance/collectors/numa_stats.go
@@ -86,11 +86,11 @@ func NewNUMAStatsCollector(logger logr.Logger, config performance.CollectionConf
 	}, nil
 }
 
-func (c *NUMAStatsCollector) Collect(ctx context.Context) (any, error) {
+func (c *NUMAStatsCollector) Collect(ctx context.Context) (performance.Event, error) {
 	// First check if this is a NUMA system
 	nodes, err := c.detectNUMANodes()
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect NUMA nodes: %w", err)
+		return performance.Event{}, fmt.Errorf("failed to detect NUMA nodes: %w", err)
 	}
 
 	stats := &performance.NUMAStatistics{
@@ -107,7 +107,7 @@ func (c *NUMAStatsCollector) Collect(ctx context.Context) (any, error) {
 
 	// If not a NUMA system, return basic info
 	if !stats.Enabled {
-		return stats, nil
+		return performance.Event{Metric: performance.MetricTypeNUMAStats, Data: stats}, nil
 	}
 
 	// Collect runtime statistics for each node
@@ -133,7 +133,7 @@ func (c *NUMAStatsCollector) Collect(ctx context.Context) (any, error) {
 	}
 	c.UpdateDeltaState(stats, currentTime)
 
-	return stats, nil
+	return performance.Event{Metric: performance.MetricTypeNUMAStats, Data: stats}, nil
 }
 
 // detectNUMANodes returns a list of NUMA node IDs by scanning the sysfs directory

--- a/pkg/performance/collectors/numa_stats_test.go
+++ b/pkg/performance/collectors/numa_stats_test.go
@@ -131,7 +131,7 @@ func collectAndValidateNUMAStats(t *testing.T, collector *collectors.NUMAStatsCo
 	}
 
 	require.NoError(t, err)
-	numaStats, ok := result.(*performance.NUMAStatistics)
+	numaStats, ok := result.Data.(*performance.NUMAStatistics)
 	require.True(t, ok, "result should be *performance.NUMAStatistics")
 
 	if validate != nil {

--- a/pkg/performance/collectors/process.go
+++ b/pkg/performance/collectors/process.go
@@ -71,7 +71,7 @@ type ProcessCollector struct {
 	lastUpdateTime time.Time
 
 	// Channel management
-	ch chan any
+	ch chan performance.Event
 }
 
 // ProcessCPUTime tracks CPU usage for a process over time
@@ -122,7 +122,7 @@ func NewProcessCollector(logger logr.Logger, config performance.CollectionConfig
 	}, nil
 }
 
-func (c *ProcessCollector) Start(ctx context.Context) (<-chan any, error) {
+func (c *ProcessCollector) Start(ctx context.Context) (<-chan performance.Event, error) {
 	if c.Status() != performance.CollectorStatusDisabled {
 		return nil, fmt.Errorf("collector already running")
 	}
@@ -141,7 +141,7 @@ func (c *ProcessCollector) Start(ctx context.Context) (<-chan any, error) {
 	c.lastUpdateTime = time.Now()
 	c.mu.Unlock()
 
-	c.ch = make(chan any)
+	c.ch = make(chan performance.Event)
 	go c.runCollection(ctx)
 	return c.ch, nil
 }
@@ -171,7 +171,7 @@ func (c *ProcessCollector) runCollection(ctx context.Context) {
 			}
 
 			select {
-			case c.ch <- processes:
+			case c.ch <- performance.Event{Metric: performance.MetricTypeProcess, Data: processes}:
 			case <-ctx.Done():
 				return
 			}

--- a/pkg/performance/collectors/process_test.go
+++ b/pkg/performance/collectors/process_test.go
@@ -59,7 +59,7 @@ func TestProcessCollector(t *testing.T) {
 	for len(collections) < 2 {
 		select {
 		case data := <-dataChan:
-			processes, ok := data.([]*performance.ProcessStats)
+			processes, ok := data.Data.([]*performance.ProcessStats)
 			require.True(t, ok, "expected []*performance.ProcessStats, got %T", data)
 			collections = append(collections, processes)
 		case <-timeout:
@@ -364,7 +364,7 @@ nonvoluntary_ctxt_switches: 5`
 	select {
 	case data := <-dataChan:
 		var ok bool
-		processes, ok = data.([]*performance.ProcessStats)
+		processes, ok = data.Data.([]*performance.ProcessStats)
 		require.True(t, ok)
 		require.Len(t, processes, 1)
 	case <-timeout:

--- a/pkg/performance/collectors/system_test.go
+++ b/pkg/performance/collectors/system_test.go
@@ -155,7 +155,7 @@ func collectAndValidateSystemStats(t *testing.T, collector *collectors.SystemSta
 	}
 
 	require.NoError(t, err)
-	stats, ok := result.(*performance.SystemStats)
+	stats, ok := result.Data.(*performance.SystemStats)
 	require.True(t, ok, "result should be *performance.SystemStats")
 
 	if validate != nil {
@@ -412,7 +412,7 @@ func TestSystemStatsCollector_FilePermissions(t *testing.T) {
 	result, err := collector.Collect(context.Background())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "permission denied")
-	assert.Nil(t, result)
+	assert.Equal(t, performance.Event{}, result)
 }
 
 func TestSystemStatsCollector_DirectoryAsStatFile(t *testing.T) {
@@ -432,7 +432,7 @@ func TestSystemStatsCollector_DirectoryAsStatFile(t *testing.T) {
 
 	result, err := collector.Collect(context.Background())
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, performance.Event{}, result)
 }
 
 func TestSystemStatsCollector_InterfaceCompliance(t *testing.T) {

--- a/pkg/performance/collectors/tcp.go
+++ b/pkg/performance/collectors/tcp.go
@@ -97,13 +97,13 @@ func NewTCPCollector(logger logr.Logger, config performance.CollectionConfig) (*
 	}, nil
 }
 
-func (c *TCPCollector) Collect(ctx context.Context) (any, error) {
+func (c *TCPCollector) Collect(ctx context.Context) (performance.Event, error) {
 	currentTime := time.Now()
 
 	// Collect current statistics
 	currentStats, err := c.collectTCPStats()
 	if err != nil {
-		return nil, err
+		return performance.Event{}, err
 	}
 
 	shouldCalc, reason := c.ShouldCalculateDeltas(currentTime)
@@ -112,19 +112,19 @@ func (c *TCPCollector) Collect(ctx context.Context) (any, error) {
 		if c.IsFirst {
 			c.UpdateDeltaState(currentStats, currentTime)
 		}
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeTCP, Data: currentStats}, nil
 	}
 
 	previousStats, ok := c.LastSnapshot.(*performance.TCPStats)
 	if !ok || previousStats == nil {
 		c.UpdateDeltaState(currentStats, currentTime)
-		return currentStats, nil
+		return performance.Event{Metric: performance.MetricTypeTCP, Data: currentStats}, nil
 	}
 
 	c.calculateTCPDeltas(currentStats, previousStats, currentTime, c.Config)
 	c.UpdateDeltaState(currentStats, currentTime)
 
-	return currentStats, nil
+	return performance.Event{Metric: performance.MetricTypeTCP, Data: currentStats}, nil
 }
 
 // collectTCPStats gathers TCP statistics from multiple proc files

--- a/pkg/performance/collectors/tcp_test.go
+++ b/pkg/performance/collectors/tcp_test.go
@@ -66,7 +66,7 @@ func collectAndValidate(t *testing.T, collector *collectors.TCPCollector) *perfo
 	result, err := collector.Collect(ctx)
 	require.NoError(t, err)
 
-	stats, ok := result.(*performance.TCPStats)
+	stats, ok := result.Data.(*performance.TCPStats)
 	require.True(t, ok, "expected *performance.TCPStats, got %T", result)
 	require.NotNil(t, stats.ConnectionsByState)
 
@@ -684,7 +684,7 @@ TcpExt: 5 3 2 8 12 25 40 30 100
 		result1, err := collector.Collect(context.Background())
 		require.NoError(t, err)
 
-		stats1, ok := result1.(*performance.TCPStats)
+		stats1, ok := result1.Data.(*performance.TCPStats)
 		require.True(t, ok)
 
 		// Verify basic stats are collected
@@ -717,7 +717,7 @@ TcpExt: 7 4 3 10 15 30 45 35 110
 		result2, err := collector.Collect(context.Background())
 		require.NoError(t, err)
 
-		stats2, ok := result2.(*performance.TCPStats)
+		stats2, ok := result2.Data.(*performance.TCPStats)
 		require.True(t, ok)
 
 		// Verify updated stats
@@ -783,7 +783,7 @@ Tcp: 1 200 120000 -1 1000 500 10 5 50 100000 95000 200 0 15 0
 			result, err := collector.Collect(context.Background())
 			require.NoError(t, err)
 
-			stats, ok := result.(*performance.TCPStats)
+			stats, ok := result.Data.(*performance.TCPStats)
 			require.True(t, ok)
 
 			// Basic stats should be present
@@ -836,7 +836,7 @@ Tcp: 1 200 120000 -1 100 50 5 2 25 5000 4500 10 0 8 0
 		result, err := collector.Collect(context.Background())
 		require.NoError(t, err)
 
-		stats, ok := result.(*performance.TCPStats)
+		stats, ok := result.Data.(*performance.TCPStats)
 		require.True(t, ok)
 		require.NotNil(t, stats.Delta)
 
@@ -865,7 +865,7 @@ Tcp: 1 200 120000 -1 100 50 5 2 25 5000 4500 10 0 8 0
 		// Collection should fail gracefully
 		result, err := collector.Collect(context.Background())
 		assert.Error(t, err)
-		assert.Nil(t, result)
+		assert.Equal(t, performance.Event{}, result)
 		assert.Contains(t, err.Error(), "no such file or directory")
 	})
 
@@ -895,21 +895,21 @@ Tcp: 1 200 120000 -1 1000 500 10 5 50 100000 95000 200 0 15 0
 		// First collection
 		result1, err := collector.Collect(context.Background())
 		require.NoError(t, err)
-		stats1 := result1.(*performance.TCPStats)
+		stats1 := result1.Data.(*performance.TCPStats)
 		assert.Nil(t, stats1.Delta) // No delta on first collection
 
 		// Second collection too soon (under MinInterval)
 		time.Sleep(100 * time.Millisecond) // Less than MinInterval
 		result2, err := collector.Collect(context.Background())
 		require.NoError(t, err)
-		stats2 := result2.(*performance.TCPStats)
+		stats2 := result2.Data.(*performance.TCPStats)
 		assert.Nil(t, stats2.Delta) // Should skip delta calculation
 
 		// Third collection after too long (over MaxInterval)
 		time.Sleep(1200 * time.Millisecond) // More than MaxInterval
 		result3, err := collector.Collect(context.Background())
 		require.NoError(t, err)
-		stats3 := result3.(*performance.TCPStats)
+		stats3 := result3.Data.(*performance.TCPStats)
 		assert.Nil(t, stats3.Delta) // Should skip delta calculation due to large interval
 	})
 }

--- a/pkg/performance/continuous_collector.go
+++ b/pkg/performance/continuous_collector.go
@@ -25,7 +25,7 @@ type ContinuousCollectionConfig struct {
 // activeCollector holds a collector's metadata and channel
 type activeCollector struct {
 	metricType MetricType
-	channel    <-chan any
+	channel    <-chan Event
 }
 
 // CollectAllMetrics starts continuous collection of all available performance metrics.
@@ -121,14 +121,14 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 	// Since we know our collector types at compile time, we can use a static select.
 	// We'll set up channels for each known collector type, using nil for unavailable ones.
 	var (
-		cpuChan     <-chan any
-		memoryChan  <-chan any
-		diskChan    <-chan any
-		networkChan <-chan any
-		systemChan  <-chan any
-		loadChan    <-chan any
-		tcpChan     <-chan any
-		processChan <-chan any
+		cpuChan     <-chan Event
+		memoryChan  <-chan Event
+		diskChan    <-chan Event
+		networkChan <-chan Event
+		systemChan  <-chan Event
+		loadChan    <-chan Event
+		tcpChan     <-chan Event
+		processChan <-chan Event
 	)
 
 	// Map collectors to their specific channels
@@ -161,8 +161,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			return
 
 		case data, ok := <-cpuChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeCPU, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeCPU, data.Data); err != nil {
 					logger.Error(err, "Failed to publish CPU data")
 				} else {
 					logger.V(2).Info("Published CPU data")
@@ -173,8 +173,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-memoryChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeMemory, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeMemory, data.Data); err != nil {
 					logger.Error(err, "Failed to publish memory data")
 				} else {
 					logger.V(2).Info("Published memory data")
@@ -185,8 +185,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-diskChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeDisk, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeDisk, data.Data); err != nil {
 					logger.Error(err, "Failed to publish disk data")
 				} else {
 					logger.V(2).Info("Published disk data")
@@ -197,8 +197,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-networkChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeNetwork, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeNetwork, data.Data); err != nil {
 					logger.Error(err, "Failed to publish network data")
 				} else {
 					logger.V(2).Info("Published network data")
@@ -209,8 +209,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-systemChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeSystem, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeSystem, data.Data); err != nil {
 					logger.Error(err, "Failed to publish system data")
 				} else {
 					logger.V(2).Info("Published system data")
@@ -221,8 +221,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-loadChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeLoad, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeLoad, data.Data); err != nil {
 					logger.Error(err, "Failed to publish load data")
 				} else {
 					logger.V(2).Info("Published load data")
@@ -233,8 +233,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-tcpChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeTCP, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeTCP, data.Data); err != nil {
 					logger.Error(err, "Failed to publish TCP data")
 				} else {
 					logger.V(2).Info("Published TCP data")
@@ -245,8 +245,8 @@ func (m *Manager) handleCollectorData(ctx context.Context, collectors []activeCo
 			}
 
 		case data, ok := <-processChan:
-			if ok && data != nil {
-				if err := m.PublishCollectorData(MetricTypeProcess, data); err != nil {
+			if ok && data.Data != nil {
+				if err := m.PublishCollectorData(MetricTypeProcess, data.Data); err != nil {
 					logger.Error(err, "Failed to publish process data")
 				} else {
 					logger.V(2).Info("Published process data")

--- a/pkg/performance/types.go
+++ b/pkg/performance/types.go
@@ -39,6 +39,11 @@ const (
 	MetricTypeNetworkInfo MetricType = "network_info"
 )
 
+type Event struct {
+	Metric MetricType
+	Data   any
+}
+
 // DeltaCalculationMode represents how delta/rate calculations are performed
 type DeltaCalculationMode string
 

--- a/tools/collector-bench/main.go
+++ b/tools/collector-bench/main.go
@@ -149,7 +149,7 @@ func testCollector(collector performance.PointCollector) CollectorResult {
 	result.Error = err
 	result.Data = data
 
-	if data != nil {
+	if data.Data != nil {
 		result.DataSize = estimateDataSize(data)
 	} else {
 		result.DataSize = 0


### PR DESCRIPTION
Instead of returning any, collectors now return Event which contains the collected data as well as the MetricType for the data. This is to make collecting data from multiple collectors of different metric types easier.

A followup PR will introduce a performance Manager which dynamically manages the lifecycle of collectors configured by the config agent and export the collector data to the metrics router. In order to do this, the manager needs to know what the metric type the collector data is for dynamically from various collectors