### PR TITLE
feat: add antimetal resource attribute to OpenTelemetry metrics

### DIFF
--- a/internal/metrics/consumers/otel/consumer.go
+++ b/internal/metrics/consumers/otel/consumer.go
@@ -154,7 +154,7 @@ func (c *Consumer) initOpenTelemetry(ctx context.Context) error {
 		"",
 		semconv.ServiceName(c.config.ServiceName),
 		semconv.ServiceVersion(c.config.ServiceVersion),
-		attribute.String("antimetal", "true"),
+		attribute.String("telemetry.distro.name", "antimetal-agent"),
 	)
 
 	// Create meter provider

--- a/internal/metrics/consumers/otel/consumer.go
+++ b/internal/metrics/consumers/otel/consumer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/metric"
 	metricSDK "go.opentelemetry.io/otel/sdk/metric"
@@ -153,6 +154,7 @@ func (c *Consumer) initOpenTelemetry(ctx context.Context) error {
 		"",
 		semconv.ServiceName(c.config.ServiceName),
 		semconv.ServiceVersion(c.config.ServiceVersion),
+		attribute.String("antimetal", "true"),
 	)
 
 	// Create meter provider


### PR DESCRIPTION
## Summary
- Adds `antimetal=\"true\"` attribute to all OpenTelemetry metrics as a resource attribute
- Enables easy filtering and identification of Antimetal agent metrics in observability platforms
- Implements attribute at resource level for efficiency (sent once per batch, not per data point)

## Motivation
When running multiple OpenTelemetry sources in the same observability platform, it's important to be able to filter and identify metrics from the Antimetal agent specifically. This change adds a consistent `antimetal="true"` tag to all exported metrics.

## Changes
- Modified `internal/metrics/consumers/otel/consumer.go` to add the antimetal attribute to resource attributes
- Added required import for the attribute package

## Benefits
- **Filtering**: Can filter metrics in observability platforms using `antimetal="true"`
- **Dashboards**: Create dashboards specifically for Antimetal agent metrics
- **Alerts**: Set up alerts that only trigger on Antimetal agent metrics
- **Multi-source environments**: Distinguish Antimetal metrics from other OTEL sources

## Testing
- Code passes `make fmt` and `make lint`
- Attribute is added at the resource level following OpenTelemetry best practices

## Impact
All metrics will now include the `antimetal="true"` attribute in their resource attributes. For example:
- `otel.system.cpu.load_average.1m` with `antimetal="true"`
- `otel.system.memory.usage` with `antimetal="true"`
- etc.