### PR TITLE
refactor(metrics): remove EventType from MetricEvent

### DIFF
--- a/internal/metrics/consumers/debug/consumer.go
+++ b/internal/metrics/consumers/debug/consumer.go
@@ -198,9 +198,6 @@ func (c *Consumer) logEventText(event metrics.MetricEvent) error {
 		if event.ClusterName != "" {
 			parts = append(parts, fmt.Sprintf("Cluster: %s", event.ClusterName))
 		}
-		if string(event.EventType) != "" {
-			parts = append(parts, fmt.Sprintf("Type: %s", string(event.EventType)))
-		}
 	}
 
 	if c.config.LogLevel >= 2 {
@@ -238,7 +235,6 @@ func (c *Consumer) logEventText(event metrics.MetricEvent) error {
 func (c *Consumer) createEventSummary(event metrics.MetricEvent) *MetricEventSummary {
 	summary := &MetricEventSummary{
 		MetricType:  string(event.MetricType), // Explicit conversion needed for struct field
-		EventType:   string(event.EventType),
 		Source:      event.Source,
 		NodeName:    event.NodeName,
 		ClusterName: event.ClusterName,

--- a/internal/metrics/consumers/debug/types.go
+++ b/internal/metrics/consumers/debug/types.go
@@ -23,7 +23,6 @@ type LogEntry struct {
 // MetricEventSummary provides a condensed view of metric events for logging
 type MetricEventSummary struct {
 	MetricType  string `json:"metric_type"`
-	EventType   string `json:"event_type"`
 	Source      string `json:"source"`
 	NodeName    string `json:"node_name"`
 	ClusterName string `json:"cluster_name"`

--- a/internal/metrics/consumers/otel/consumer.go
+++ b/internal/metrics/consumers/otel/consumer.go
@@ -336,7 +336,6 @@ func (c *Consumer) processEvent(event metrics.MetricEvent) error {
 	// Log detailed event information at debug level
 	c.logger.V(2).Info("Processing metrics event",
 		"metric_type", event.MetricType,
-		"event_type", event.EventType,
 		"source", event.Source,
 		"node", event.NodeName,
 		"cluster", event.ClusterName,

--- a/internal/metrics/event.go
+++ b/internal/metrics/event.go
@@ -59,14 +59,6 @@ const (
 //   - "network_info": Static network information
 //   - "numa_stats": NUMA node statistics
 //
-// EventType indicates how to interpret the metric:
-//   - "gauge": Point-in-time value (e.g., current memory usage)
-//   - "counter": Monotonically increasing value (e.g., bytes sent)
-//   - "histogram": Distribution of values
-//   - "timing": Duration measurements
-//   - "set": Unique value counting
-//   - "snapshot": Complete state capture
-//
 // The Data field contains the actual metric payload, typically one of the
 // performance collector types from pkg/performance (all using pointers for efficiency):
 //   - *performance.LoadStats for MetricTypeLoad
@@ -85,6 +77,10 @@ const (
 //   - *performance.NUMAStatistics for MetricTypeNUMAStats
 //   - []*performance.CgroupCPUStats for MetricTypeCgroupCPU
 //   - []*performance.CgroupMemoryStats for MetricTypeCgroupMemory
+//
+// Note: Consumers determine how to interpret metrics (gauge, counter, histogram, etc.)
+// based on the actual field semantics within the Data payload, as many metric types
+// contain mixed data (e.g., network stats have both gauges and counters).
 type MetricEvent struct {
 	// Event metadata
 	Timestamp   time.Time
@@ -94,23 +90,10 @@ type MetricEvent struct {
 
 	// Metric identification
 	MetricType MetricType
-	EventType  EventType
 
 	// Metric data (contains the actual performance data)
 	Data any
 }
-
-// EventType indicates the nature of the metric event
-type EventType string
-
-const (
-	EventTypeGauge     EventType = "gauge"     // Point-in-time value
-	EventTypeCounter   EventType = "counter"   // Monotonically increasing value
-	EventTypeHistogram EventType = "histogram" // Distribution of values
-	EventTypeTiming    EventType = "timing"    // Duration measurements
-	EventTypeSet       EventType = "set"       // Unique value counting
-	EventTypeSnapshot  EventType = "snapshot"  // Complete snapshot of data
-)
 
 // Router defines the interface for routing metrics events to consumers
 type Router interface {

--- a/internal/perf/manager/manager.go
+++ b/internal/perf/manager/manager.go
@@ -9,6 +9,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -19,11 +20,18 @@ import (
 	"github.com/antimetal/agent/internal/metrics"
 	agentv1 "github.com/antimetal/agent/pkg/api/antimetal/agent/v1"
 	"github.com/antimetal/agent/pkg/channel"
-	"github.com/antimetal/agent/pkg/config/environment"
 	"github.com/antimetal/agent/pkg/performance"
 	// register all collectors to the registry
 	_ "github.com/antimetal/agent/pkg/performance/collectors"
 )
+
+// getEnvOrDefault returns the value of the environment variable or a default value
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
 
 type collectorInstance struct {
 	version string
@@ -79,17 +87,15 @@ func New(configLoader config.Loader, router metrics.Router, opts ...Option) (*ma
 
 	perfEvents := channel.NewMerger[performance.Event]()
 
-	// Get host paths from environment
-	hostPaths := environment.GetHostPaths()
-
+	// Use default paths, can be overridden with options
 	m := &manager{
 		configLoader:      configLoader,
 		router:            router,
 		perfEvents:        perfEvents,
 		runningCollectors: make(map[string]*collectorInstance),
-		procPath:          hostPaths.Proc,
-		sysPath:           hostPaths.Sys,
-		devPath:           hostPaths.Dev,
+		procPath:          getEnvOrDefault("HOST_PROC", "/proc"),
+		sysPath:           getEnvOrDefault("HOST_SYS", "/sys"),
+		devPath:           getEnvOrDefault("HOST_DEV", "/dev"),
 	}
 	for _, opt := range opts {
 		opt(m)

--- a/pkg/channel/doc.go
+++ b/pkg/channel/doc.go
@@ -1,0 +1,8 @@
+// Copyright Antimetal, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+// Package channel provides utilities for working with Go channels.
+package channel


### PR DESCRIPTION
## Summary
Removes the `EventType` field from `MetricEvent` struct as it was providing an overly simplistic classification that doesn't match real-world metric semantics.

## Context
This PR builds on #211's performance collection refactoring.

The `EventType` field was attempting to classify entire metric payloads as single types (gauge, counter, histogram, etc), but metrics often contain mixed data types. For example:
- **Network stats**: Have both point-in-time values (current speed) and cumulative counters (bytes transmitted)
- **Disk stats**: Include instantaneous values (queue_depth) and cumulative counters (reads_completed)
- **Memory stats**: Mix gauges (available memory) with counters (page faults)

## Changes
- ✅ Removed `EventType` field from `MetricEvent` struct
- ✅ Removed `EventType` type definition and constants
- ✅ Updated debug consumer to remove EventType from logging
- ✅ Updated OTel consumer to remove EventType from debug logs
- ✅ Removed `getEventType()` helper from new perf manager introduced in #211

## Benefits
- **More accurate data handling**: Consumers can properly handle mixed data types within a single metric
- **Simpler code**: Removes unnecessary abstraction layer
- **Better flexibility**: Each consumer interprets metrics based on their specific needs
- **No breaking changes**: The OpenTelemetry transformer already makes its own decisions about metric types

## Testing
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Metrics pipeline continues to function normally

## Notes
The OpenTelemetry transformer already examines each field's semantics to create the appropriate instrument type (gauge, counter, etc.), so this change actually enables more accurate metric recording.