### PR TITLE
Profiler Event Struct && BPF Ring Buffer for profiler implementation

### DIFF
--- a/ebpf/include/profiler_types.h
+++ b/ebpf/include/profiler_types.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * This header defines the data structures shared between BPF and userspace
+ * for the continuous profiler.
+ *
+ * The profile_event structure is designed to be exactly 32 bytes for optimal
+ * memory efficiency and to enable zero-copy operations with BPF ring buffers.
+ */
+
+#ifndef __PROFILER_TYPES_H
+#define __PROFILER_TYPES_H
+
+/*
+ * Event flags for profiler events.
+ * These flags provide metadata about the profiling event and stack trace quality.
+ */
+
+/* User stack trace was truncated due to depth limit */
+#define PROF_FLAG_USER_STACK_TRUNCATED   (1 << 0)
+
+/* Kernel stack trace was truncated due to depth limit */
+#define PROF_FLAG_KERNEL_STACK_TRUNCATED (1 << 1)
+
+/* Stack ID collision occurred (hash collision in stack map) */
+#define PROF_FLAG_STACK_COLLISION        (1 << 2)
+
+/* Timestamp was adjusted (e.g., for clock skew correction) */
+#define PROF_FLAG_TIME_ADJUSTED          (1 << 3)
+
+/* Reserved for future use: bits 4-31 */
+
+/*
+ * Fixed 32-byte profiling event structure.
+ *
+ * This structure is carefully designed to be exactly 32 bytes with proper
+ * alignment on all supported architectures (x86_64, arm64). All fields are
+ * naturally aligned to avoid padding.
+ *
+ * Memory layout:
+ *   Offset  Size  Field
+ *   0       8     timestamp
+ *   8       4     pid
+ *   12      4     tid
+ *   16      4     user_stack_id
+ *   20      4     kernel_stack_id
+ *   24      4     cpu
+ *   28      4     flags
+ *   Total: 32 bytes
+ */
+struct profile_event {
+	/* Timestamp in nanoseconds since boot (from bpf_ktime_get_ns()) */
+	__u64 timestamp;
+
+	/* Process ID of the sampled task */
+	__s32 pid;
+
+	/* Thread ID of the sampled task */
+	__s32 tid;
+
+	/* Stack trace ID for user-space stack (from BPF_MAP_TYPE_STACK_TRACE) */
+	__s32 user_stack_id;
+
+	/* Stack trace ID for kernel-space stack (from BPF_MAP_TYPE_STACK_TRACE) */
+	__s32 kernel_stack_id;
+
+	/* CPU number where the sample was taken */
+	__u32 cpu;
+
+	/* Event flags (combination of PROF_FLAG_* values) */
+	__u32 flags;
+} __attribute__((packed)); /* Ensure no compiler-added padding */
+
+/*
+ * Compile-time assertions to verify structure size and alignment.
+ * These will cause compilation to fail if the structure is not exactly 32 bytes.
+ */
+_Static_assert(sizeof(struct profile_event) == 32,
+	       "profile_event must be exactly 32 bytes");
+
+#endif /* __PROFILER_TYPES_H */
+
+


### PR DESCRIPTION
Hey guys, love the stuff you're cooking here. Always wanted to learn eBPF so thanks for documenting all your issues here

This PR aims to tackle these two issues:
1. [feat(profiler): Define 32-byte profile event structure](https://github.com/antimetal/system-agent/issues/126) ✅
1. [feat(profiler): Implement BPF ring buffer for profiler](https://github.com/antimetal/system-agent/issues/125)

When reading through the requirements of the second issue, I realized that you want to have a ring buffer per-CPU. Ring Buffers are designed to be shared across all CPUs. What would be the reason to have isolated ring buffers per CPU?

According to eBPF docs, if you were to proceed with implementing per-CPU ring buffers, you would lose major benefits that a single centralized Ring Buffer brings to the table. They are:
1. Memory footprint - BPF ringbuf memory usage scales better with increased amount of CPUs, because going from 16 to 32 CPUs doesn’t necessarily require twice as big a buffer to accommodate more load.

2. Event ordering - having a per-CPU ring buffer inherently introduces a problem of having to sync related events that are scattered across ring buffers/CPUs, making the application that needs to read those events more complex. (for example: fork(), exec(), and exit() can happen in a very rapid succession on different CPUs for short-lived processes due to the kernel scheduler migrating them from one CPU to another)

Let me know if i'm wrong here and feel free to correct! I would love to try and tackle the second issue, but before i do that, i'd like to get some clarity on whether you want to go per-CPU or single buffer. Thank you!

Reference: 
https://nakryiko.com/posts/bpf-ringbuf/
https://www.kernel.org/doc/html/latest/bpf/ringbuf.html