### PR TITLE
fix(resource): lower badger memory usage even further

### DIFF
--- a/internal/resource/store/store.go
+++ b/internal/resource/store/store.go
@@ -148,9 +148,10 @@ func New(opts ...Option) (*store, error) {
 	db, err := badger.Open(
 		badger.DefaultOptions(path).
 			WithInMemory(path == "").
-			WithNumMemtables(3).
-			WithBlockCacheSize(128 << 20).
-			WithIndexCacheSize(64 << 20).
+			WithMemTableSize(32 << 20).
+			WithNumMemtables(2).
+			WithBlockCacheSize(64 << 20).
+			WithIndexCacheSize(32 << 20).
 			WithLogger(badgerLog),
 	)
 	if err != nil {


### PR DESCRIPTION
Still getting OOM kills on 512MB due to multiple memtables + caches getting really close to the limit.