### PR TITLE
fix(ci): install bpftool for vmlinux.h generation in CI builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,6 +94,15 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
 
+    - name: Install bpftool from libbpf
+      run: |
+        # Build bpftool from libbpf source (works with any kernel)
+        git clone --recurse-submodules --depth 1 https://github.com/libbpf/bpftool.git /tmp/bpftool
+        cd /tmp/bpftool/src
+        make
+        sudo make install
+        bpftool version
+
     - name: Check generated files are up to date
       run: make gen-check
 
@@ -129,6 +138,15 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
+
+    - name: Install bpftool from libbpf
+      run: |
+        # Build bpftool from libbpf source (works with any kernel)
+        git clone --recurse-submodules --depth 1 https://github.com/libbpf/bpftool.git /tmp/bpftool
+        cd /tmp/bpftool/src
+        make
+        sudo make install
+        bpftool version
 
     - name: Build agent binary
       run: make build
@@ -209,6 +227,15 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq clang llvm libelf-dev libbpf-dev
+
+    - name: Install bpftool from libbpf
+      run: |
+        # Build bpftool from libbpf source (works with any kernel)
+        git clone --recurse-submodules --depth 1 https://github.com/libbpf/bpftool.git /tmp/bpftool
+        cd /tmp/bpftool/src
+        make
+        sudo make install
+        bpftool version
 
     - name: Generate code
       run: |


### PR DESCRIPTION
## Summary

Fixes GitHub Actions build failures by installing `bpftool` in the CI environment.

## Problem

With new kernel version in the environment, the ARM64 build job was failing with:
```
make: *** [Makefile:185: generate-vmlinux] Error 2
```

The error occurred when `ebpf/scripts/generate_vmlinux.sh` attempted to convert kernel BTF to vmlinux.h header file. The script requires `bpftool` which was not available in the build environment.

## Solution

Don't rely on package versions, and build the bpftool utility from source instead...

## Changes

Updated package installation in three workflow jobs:
- Generation Check job
- Build Agent Binary jobs (amd64 and arm64)  
- Build Test Artifacts job

## Testing

This fix will be validated by the CI pipeline itself - the build should now succeed where it was previously failing.
