### PR TITLE
ci: add Source Guard push tripwire

### DIFF
--- a/.github/workflows/source-guard.yml
+++ b/.github/workflows/source-guard.yml
@@ -1,0 +1,8 @@
+name: Source Guard
+on:
+  push:
+    branches: ["**"]
+jobs:
+  guard:
+    uses: antimetal/.github/.github/workflows/source-guard.yml@main
+    secrets: inherit


### PR DESCRIPTION
Installs the org-wide **Source Guard** push tripwire — a small caller that invokes the shared reusable workflow in the private `antimetal/.github` repo. On every push it scans each commit for the 2026-06 build-loader supply-chain signature and alerts Slack `#bugs` on a hit (alert-only — no auto-revert).

The detection logic + scanner live in `antimetal/.github`; this caller is the only per-repo footprint. Requires the org `SLACK_BOT_TOKEN` secret (already set, all repos). Proven end-to-end on `antimetal/blog-john`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)