### PR TITLE
ci: slim Source Guard caller

### DIFF
--- a/.github/workflows/source-guard.yml
+++ b/.github/workflows/source-guard.yml
@@ -21,18 +21,6 @@ jobs:
           repository: antimetal/.github
           token: ${{ steps.tok.outputs.token }}
           path: .source-guard
-      - id: scan
-        uses: ./.source-guard/.github/actions/malware-scan
-      - name: Alert Slack
-        if: steps.scan.outputs.infected == 'true'
-        continue-on-error: true
-        uses: slackapi/slack-github-action@v2.0.0
+      - uses: ./.source-guard/.github/actions/guard
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: "#bugs"
-            text: ":rotating_light: *Malware signature pushed* to `${{ github.repository }}` @ `${{ github.ref_name }}` by `${{ github.actor }}`."
-      - name: Fail the run on a hit
-        if: steps.scan.outputs.infected == 'true'
-        run: exit 1
+          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Slims the public Source Guard caller: the scan + Slack-alert + fail logic now lives in the private `antimetal/.github` composite action. This removes the `#bugs` channel name and the signature language from this public repo, drops the `malware-scan` path, and shrinks the file. Functionally identical — validated green on `system-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)